### PR TITLE
Wording 1.2.3

### DIFF
--- a/includes/admin/transifex-live-integration-settings-template.php
+++ b/includes/admin/transifex-live-integration-settings-template.php
@@ -4,7 +4,7 @@
 	<form id="settings_form" method="post" enctype="multipart/form-data">
 		<?php wp_nonce_field( 'transifex_live_settings', 'transifex_live_nonce' ); ?>
 		<p><?php _e( 'Translate your WordPress site without complexities.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
-    <p><?php _e( 'Before using this plugin, be sure you have a Transifex Live API key. ' ); ?>&nbsp;<a href="<?php echo $settings['urls']['api_key_landing_page']; ?>"><?php _e( 'Click here to sign up and get an API key.' ) ?></a>
+		<p><?php _e( 'Before using this plugin, be sure you have a Transifex Live API key. ' ); ?>&nbsp;<a href="<?php echo $settings['urls']['api_key_landing_page']; ?>"><?php _e( 'Click here to sign up and get an API key.' ) ?></a>
 		<table class="form-table">
             <tbody>
                 <tr>
@@ -21,7 +21,7 @@
 				<tr valign="top">
 				</tr></table>
 		<h2>Advanced SEO Settings</h2>
-    <p>This plugin lets you set unique, language/region-specific URLs for your site and tells search engines what language a page is in. This is done by creating new language subdirectories through the plugin, or by pointing to existing language subdomains. In all cases, the plugin will add the Transifex Live JavaScript snippet to your site.</p>
+		<p>This plugin lets you set unique, language/region-specific URLs for your site and tells search engines what language a page is in. This is done by creating new language subdirectories through the plugin, or by pointing to existing language subdomains. In all cases, the plugin will add the Transifex Live JavaScript snippet to your site.</p>
 		<table class="form-table">
 			<tr>
 				<td>

--- a/includes/admin/transifex-live-integration-settings-template.php
+++ b/includes/admin/transifex-live-integration-settings-template.php
@@ -1,15 +1,14 @@
 <div class="wrap transifex-live-settings">
-    <h2><?php _e( 'Transifex Live Plugin', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></h2>
+    <h2><?php _e( 'Transifex Live Translation Plugin Settings', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></h2>
 
 	<form id="settings_form" method="post" enctype="multipart/form-data">
 		<?php wp_nonce_field( 'transifex_live_settings', 'transifex_live_nonce' ); ?>
-		<p><?php _e( 'Transifex Live Plugin helps you to easily translate your WordPress site.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
-		<p><?php _e( 'This plugin depends on the Transifex Live service.  You will need an API key in order to use this plugin.' ); ?></p>
-		<p><a href="<?php echo $settings['urls']['api_key_landing_page']; ?>"><?php _e( "If you don't have a key, click here to sign up and get one" ) ?></a></p>
+		<p><?php _e( 'Translate your WordPress site without complexities.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
+    <p><?php _e( 'Before using this plugin, be sure you have a Transifex Live API key. ' ); ?>&nbsp;<a href="<?php echo $settings['urls']['api_key_landing_page']; ?>"><?php _e( 'Click here to sign up and get an API key.' ) ?></a>
 		<table class="form-table">
             <tbody>
                 <tr>
-                    <th scope="row"><label for="transifex_live_settings[api_key]"><?php _e( 'Transifex Live API Key:', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></label></th>
+                    <th scope="row"><label for="transifex_live_settings[api_key]"><?php _e( 'Transifex Live API Key', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></label></th>
                     <td>
                         <p>
 							<input required name="transifex_live_settings[api_key]" type="text" id="transifex_live_settings_api_key" value="<?php echo $settings['api_key']; ?>" class="regular-text" placeholder="<?php _e( 'This field is required.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?>">
@@ -21,40 +20,39 @@
                 </tr>
 				<tr valign="top">
 				</tr></table>
-		<h2>Advanced SEO Configuration</h2>
+		<h2>Advanced SEO Settings</h2>
+    <p>This plugin lets you set unique, language/region-specific URLs for your site and tells search engines what language a page is in. This is done by creating new language subdirectories through the plugin, or by pointing to existing language subdomains. In all cases, the plugin will add the Transifex Live JavaScript snippet to your site.</p>
 		<table class="form-table">
 			<tr>
 				<td>
 					<label for="transifex_live_settings_url_options">
-						<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_none" name="transifex_live_settings[url_options_none]" value="1" <?php echo $url_options_none ?>> Disabled - In this mode the plugin will simply add the Transifex Live Javascript snippet to every page on your site.  <a href="http://docs.transifex.com/integrations/wordpress/#disabled-mode"><b>Learn more</b></a></p>
-						<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_subdirectory" name="transifex_live_settings[url_options_subdirectory]" value="2" <?php echo $url_options_subdirectory ?>> Subdirectory - In this mode the plugin will add localized rewrites to your url path based on the languages published in Transifex Live.  <a href="http://docs.transifex.com/integrations/wordpress/#subdirectories"><b>Learn more</b></a></p>
-						<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_subdomain" name="transifex_live_settings[url_options_subdomain]" value="3" <?php echo $url_options_subdomain ?>> Subdomain  - In this mode the plugin will integrate with existing localized subdomain urls.  <a href="http://docs.transifex.com/integrations/wordpress/#subdomains"><b>Learn more</b></a></p>
+						<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_none" name="transifex_live_settings[url_options_none]" value="1" <?php echo $url_options_none ?>> Disabled – Just add the Transifex Live JavaScript snippet to my site. <a href="http://docs.transifex.com/integrations/wordpress/#disabled"><b>Learn more</b></a>.</p>
+						<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_subdirectory" name="transifex_live_settings[url_options_subdirectory]" value="2" <?php echo $url_options_subdirectory ?>> Subdirectory – Create new language subdirectories through the plugin, e.g. <code>http://www.example.com/fr/</code>. <a href="http://docs.transifex.com/integrations/wordpress/#subdirectories"><b>Learn more</b></a>.</p>
+						<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_subdomain" name="transifex_live_settings[url_options_subdomain]" value="3" <?php echo $url_options_subdomain ?>> Subdomain – Point the plugin to existing language subdomains, e.g. <code>http://fr.example.com</code>. <a href="http://docs.transifex.com/integrations/wordpress/#subdomains"><b>Learn more</b></a>.</p>
 						<input type="hidden" id="transifex_live_settings_url_options" name="transifex_live_settings[url_options]" value="<?php echo $url_options ?>" >
 					</label>
-					<p><b>Note:</b>  When Advanced SEO modes are enabled, the plugin will automatically add hreflang tags to the header of your site.  <a href="http://docs.transifex.com/integrations/wordpress/#hreflang-tag"><b>Learn more</b></a></p>
+					<p><b>Note:</b> When you choose the Subdirectory or Subdomain options, the plugin will automatically <a href="http://docs.transifex.com/integrations/wordpress/#hreflang-tag"><b>add hreflang tags</b></a> to the header of your site.</p>
 				</td></tr></table>
 		<table class="form-table">
 			<tr class="custom-urls-settings">
 				<th scope="row" class="titledesc adds-rewrites">Published Languages</th>
 				<td>
-					<p class="url-structure-subdirectory">The plugin has loaded your language codes based off your published languages from Transifex Live.  Your urls will follow this pattern: <code><?php echo $site_url_subdirectory_example ?></code>  <a href="http://docs.transifex.com/integrations/wordpress/#published-languages"><b>Learn more</b></a></p>
-					<p class="url-structure-subdomain">The plugin has loaded your language codes based off your published languages from Transifex Live.  You will need to setup your subdomains to match the following pattern: <code><?php echo $site_url_subdomain_example ?></code>  <a href="http://docs.transifex.com/integrations/wordpress/#published-languages"><b>Learn more</b></a></p>
+					<p class="url-structure-subdirectory">Below is a list of languages published from Transifex Live. For each language, you can set the name of the subdirectory. Your URLs will follow the pattern of <code>www.example.com/%lang%/</code>, with the language code always appearing immediately after your domain.</p>
+					<p class="url-structure-subdomain">Below is a list of languages published from Transifex Live. If you’ve set up language subdomains for your site, enter the language subdomain names below. So if <code>fr.example.com</code> is the subdomain for your French site, put in <code>fr</code>. If you don’t have language subdomains set up yet, be sure they match what’s below when you set them up.</p>
 					<br/>
 					<input type="hidden" value="<?php echo $source_language ?>" name="transifex_live_settings[source_language]" id="transifex_live_settings_source_language" />
 					<p id="transifex_live_languages">
-						<span id="transifex_live_languages_message">Transifex Live languages are not loaded. Please re-check your API key.</span>
+						<span id="transifex_live_languages_message">Your languages couldn't be loaded. Please re-check your API key.</span>
 					</p>
-					<p class="description" id="tagline-description">Tweak your localized urls.</p>
 				</td>
 			</tr>
 			<tr class="url-structure-subdirectory">
 				<th>Subdirectory Options</th>
 				<td>
-					<p>These options allow for fine-grained control over which WordPress objects will allow language permalinks.  <a href="http://docs.transifex.com/integrations/wordpress/#subdirectory-options"><b>Learn more</b></a></p>
+					<p>Choose which WordPress content types you want to enable language subdirectories for.</p>
 					<p><input id="transifex_live_settings_rewrite_option_all" name="transifex_live_settings[rewrite_option_all]" value="1" type="checkbox" <?php echo $checked_rewrite_option_all ?>>All</p>
 					<p><?php Transifex_Live_Integration_Settings_Util::render_url_options( $rewrite_options_array ); ?></p>
-					<p class="description" id="tagline-description">Pick which WordPress objects to add rewrites to.</p>
-					<p class="url-structure-subdirectory">Having trouble getting your localized URLs working?  <a href="http://docs.transifex.com/integrations/wordpress/#troubleshooting-tips">Check out our additional troubleshooting tips!</a></p>
+					<p class="url-structure-subdirectory">Having trouble getting language/region-specific URLs working? <a href="http://docs.transifex.com/integrations/wordpress/#troubleshooting-tips">Check out our additional troubleshooting tips!</a></p>
 					</div>
 				</td></tr>
 			</tbody>

--- a/javascript/transifex-live-integration-settings-page.js
+++ b/javascript/transifex-live-integration-settings-page.js
@@ -36,7 +36,7 @@ function transifex_live_integration_convert(l) {
         value: l['source']['code']
     };
     source_language = l['source']['code'];
-    r['source'] = s; 
+    r['source'] = s;
     r['html'] = h;
     return r;
 }
@@ -64,7 +64,7 @@ function transifexLanguages() {
     }).fail(function() {
         console.log('failed');
         jQuery('#transifex_live_settings_api_key').trigger('error');
-    }).always(function(jqXHR, textStatus) { 
+    }).always(function(jqXHR, textStatus) {
         console.log(jqXHR);
         console.log(textStatus);
     });
@@ -101,11 +101,11 @@ function addTransifexLanguages(obj) {
             onEnter: function () {
                 console.log('#transifex_live_languages:defaultState:onEnter');
                 ($('#transifex_live_settings_language_lookup').val()!=='')?this.trigger('render'):this.trigger('wait');
-               
+
             },
             events: {render : 'render',wait: 'wait'}
         },
-        wait:{  
+        wait:{
             onEnter: function () {
                 console.log('#transifex_live_languages:wait:onEnter');
             },
@@ -180,7 +180,7 @@ function addTransifexLanguages(obj) {
         validating: {
             onEnter: function () {
                 console.log('transifex_live_settings_api_key:validating:onEnter');
-                $('#transifex_live_settings_api_key_message').text('Checking Key');
+                $('#transifex_live_settings_api_key_message').text('Checking key...');
                 $('#transifex_live_settings_url_options_none').attr('disabled',true);
                 $('#transifex_live_settings_url_options_subdirectory').attr('disabled',true);
                 $('#transifex_live_settings_url_options_subdomain').attr('disabled',true);
@@ -197,7 +197,7 @@ function addTransifexLanguages(obj) {
                 $('#transifex_live_settings_url_options_subdirectory').attr('disabled',false);
                 $('#transifex_live_settings_url_options_subdomain').attr('disabled',false);
                 $('#transifex_live_languages').trigger('load');
-                $('#transifex_live_settings_api_key_message').text('Valid Key - Enabling Advanced SEO');
+                $('#transifex_live_settings_api_key_message').text('Success! Advanced SEO settings enabled.');
                 $('input#submit').prop('disabled',false);
             },
             events: {success: 'valid', change: 'validating'}
@@ -206,7 +206,7 @@ function addTransifexLanguages(obj) {
             onEnter: function () {
                 console.log('error:onEnter');
                 $('#transifex_live_settings_api_key_button').trigger('wait');
-                $('#transifex_live_settings_api_key_message').text('Error Checking Key - Please Correct Key');
+                $('#transifex_live_settings_api_key_message').text(' Oops! Please make sure you’ve entered a valid API key.');
             },
             events: {change: 'validating', validating: 'validating'}
         },
@@ -222,7 +222,7 @@ function addTransifexLanguages(obj) {
             onEnter: function () {
                 console.log('missing:onEnter');
                 $('#transifex_live_settings_api_key_button').trigger('wait');
-                $('#transifex_live_settings_api_key_message').text('Error No Languages have been Published.');
+                $('#transifex_live_settings_api_key_message').text('D’oh! No languages have been published from Transifex Live yet.');
             },
             events: {validating: 'validating'}
         },
@@ -243,7 +243,7 @@ function addTransifexLanguages(obj) {
                 $('#transifex_live_settings_url_options').trigger('none');
             },
             events: {click:'on'}
-        },  
+        },
     }, {setClass: true});
 })(jQuery);
 
@@ -261,7 +261,7 @@ function addTransifexLanguages(obj) {
                 $('#transifex_live_settings_url_options').trigger('subdirectory');
             },
             events: {click:'on'}
-        },  
+        },
     }, {setClass: true});
 })(jQuery);
 
@@ -279,7 +279,7 @@ function addTransifexLanguages(obj) {
                 $('#transifex_live_settings_url_options').trigger('subdomain');
             },
             events: {click:'on'}
-        },  
+        },
     }, {setClass: true});
 })(jQuery);
 
@@ -363,14 +363,14 @@ function addTransifexLanguages(obj) {
                 this.prop('checked', false);
                 $('.all_selector').trigger('off');
             },
-           events: {click: 'on'} 
+           events: {click: 'on'}
         },
         singleoff: {
             onEnter: function () {
                 console.log('transifex_live_settings_rewrite_option_all::singleoff::onEnter');
                 this.prop("checked", false);
             },
-           events: {click: 'on'} 
+           events: {click: 'on'}
        }
     }, {setClass: true});
 })(jQuery);
@@ -401,7 +401,7 @@ function addTransifexLanguages(obj) {
                 this.prop("checked", false);
                 $('#transifex_live_settings_rewrite_option_all').trigger('singleoff');
             },
-           events: {click: 'on', on: 'on'} 
+           events: {click: 'on', on: 'on'}
         }
     }, {setClass: true});
 })(jQuery);

--- a/tests/acceptance/PluginUICept.php
+++ b/tests/acceptance/PluginUICept.php
@@ -10,7 +10,7 @@ $I->click('Log In');
 $I->see('Dashboard');
 $I->click('Settings');
 $I->click('Transifex Live');
-$I->see('Transifex Live Plugin','h2');
+$I->see('Transifex Live Translation Plugin Settings','h2');
 $I->seeInFormFields('#settings_form',[ 
 	'transifex_live_settings[api_key]' => ''
 	]);


### PR DESCRIPTION
Updated wording in plugin. Wasn't able to update two strings:

![image](https://cloud.githubusercontent.com/assets/2788702/13165573/9fb196dc-d673-11e5-8a64-3c615a3658f4.png)

I'd like those to say Subdirectory / Subdomain depending on which option was selected.
