### PR TITLE
Support X-Transifex-Lang header in prerender requests

### DIFF
--- a/includes/lib/transifex-live-integration-prerender.php
+++ b/includes/lib/transifex-live-integration-prerender.php
@@ -168,7 +168,7 @@ STATUS;
 		$debug_html = '<!--' . "\n";
 		$page_url = home_url( $wp->request );
 		if ( !empty($lang) ) {
-			$page_url = str_replace('www', $lang, $page_url);
+			$page_url = Transifex_Live_Integration_Util::replace_lang_subdomain($page_url, $lang);
 		}
 		$page_url = rtrim( $page_url, '/' ) . '/';
 		if ( function_exists( 'curl_version' ) ) {

--- a/includes/lib/transifex-live-integration-prerender.php
+++ b/includes/lib/transifex-live-integration-prerender.php
@@ -158,8 +158,18 @@ STATUS;
 	function callback( $buffer ) {
 		global $wp;
 		$output = $buffer;
+
+		# Try to get language code from the Transifex-Lang header.
+		# This is used in the instance where subdomains have been configured
+		# outside Wordpress so it does not have any knowledge of other
+		# subdomains.
+		$lang = urlencode($_SERVER['HTTP_X_TRANSIFEX_LANG']);
+
 		$debug_html = '<!--' . "\n";
 		$page_url = home_url( $wp->request );
+		if ( !empty($lang) ) {
+			$page_url = str_replace('www', $lang, $page_url);
+		}
 		$page_url = rtrim( $page_url, '/' ) . '/';
 		if ( function_exists( 'curl_version' ) ) {
 			$curl_response = $this->call_curl( $this->prerender_url . $page_url );

--- a/includes/lib/transifex-live-integration-rewrite.php
+++ b/includes/lib/transifex-live-integration-rewrite.php
@@ -176,7 +176,7 @@ class Transifex_Live_Integration_Rewrite {
 			if ( substr($parsed['path'], 1, strlen($lang))  != $lang ) {
 				$parsed['path'] = '/' . $lang . $parsed['path'];
 			}
-			$link = self::unparse_url( $parsed );
+			$link = Transifex_Live_Integration_Util::unparse_url( $parsed );
 		}
 		return $link;
 	}
@@ -324,25 +324,6 @@ class Transifex_Live_Integration_Rewrite {
 		}
 		$retlink = $this->reverse_hard_link( $this->lang, $url, $this->languages_map, $this->source_language, $this->rewrite_pattern );
 		return $retlink;
-	}
-
-	/*
-	 * Reconstruct a parsed URL.
-	 * @param string $parsed_url The URL parsed by parse_url
-	 * @return string The final URL as a string
-	 */
-
-	function unparse_url($parsed_url) {
-		$scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
-		$host     = isset($parsed_url['host']) ? $parsed_url['host'] : '';
-		$port     = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
-		$user     = isset($parsed_url['user']) ? $parsed_url['user'] : '';
-		$pass     = isset($parsed_url['pass']) ? ':' . $parsed_url['pass']  : '';
-		$pass     = ($user || $pass) ? "$pass@" : '';
-		$path     = isset($parsed_url['path']) ? $parsed_url['path'] : '';
-		$query    = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
-		$fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
-		return "$scheme$user$pass$host$port$path$query$fragment";
 	}
 
 }

--- a/includes/transifex-live-integration-util.php
+++ b/includes/transifex-live-integration-util.php
@@ -92,4 +92,50 @@ class Transifex_Live_Integration_Util {
 		return $prerender_ok;
 	}
 
+
+	/**
+	* @param $page_url
+	* @param $lang
+	*
+	* @return mixed
+	*/
+	static function replace_lang_subdomain($page_url, $lang){
+		$url_parts = parse_url($page_url);
+		if (isset($url_parts['host'])) {
+			$host = $url_parts['host'];
+			$dots = explode('.', $host);
+			if ($dots[0] === $lang){
+				return $page_url;
+			}
+			if ($dots[0] === "www") {
+				$dots[0] = $lang;
+			} else {
+				array_unshift($dots, $lang);
+			}
+			$host = implode($dots, '.');
+			$url_parts['host'] = $host;
+			$page_url = Transifex_Live_Integration_Util::unparse_url($url_parts);
+		}
+		return $page_url;
+	}
+
+	/*
+	 * Reconstruct a parsed URL.
+	 * @param string $parsed_url The URL parsed by parse_url
+	 * @return string The final URL as a string
+	 */
+
+	static function unparse_url($parsed_url) {
+		$scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+		$host     = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+		$port     = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
+		$user     = isset($parsed_url['user']) ? $parsed_url['user'] : '';
+		$pass     = isset($parsed_url['pass']) ? ':' . $parsed_url['pass']  : '';
+		$pass     = ($user || $pass) ? "$pass@" : '';
+		$path     = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+		$query    = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+		$fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+		return "$scheme$user$pass$host$port$path$query$fragment";
+	}
+
 }

--- a/tests/unit/ReplaceSubdomainTest.php
+++ b/tests/unit/ReplaceSubdomainTest.php
@@ -1,0 +1,42 @@
+<?php
+
+class ReplaceSubdomainTest extends \PHPUnit_Framework_TestCase
+{
+
+    private $data;
+
+    protected function setUp() 
+    {
+        include_once './includes/common/plugin-debug.php';
+        include_once './includes/common/transifex-live-integration-common.php';
+        $this->data = [
+        [
+        'page_url' => 'https://www.foo.bar/about/',
+        'lang' => 'fr',
+        'result' => 'https://fr.foo.bar/about/',
+        ], [
+        'page_url' => 'https://foo.bar/about/',
+        'lang' => 'fr',
+        'result' => 'https://fr.foo.bar/about/',
+        ], [
+        'page_url' => 'http://www.foo.bar/www-is-awesome/',
+        'lang' => 'fr',
+        'result' => 'http://fr.foo.bar/www-is-awesome/',
+        ], [
+        'page_url' => 'http://www.foo.bar/about/',
+        'lang' => 'fr_FR',
+        'result' => 'http://fr_FR.foo.bar/about/',
+        ]];
+    }
+
+    public function testMe() 
+    {
+        foreach ($this->data as $d) {
+            $result = Transifex_Live_Integration_Util::replace_lang_subdomain(
+                $d['page_url'], $d['lang']
+            );
+            $this->assertEquals($d['result'], $result);
+        }
+    }
+
+}


### PR DESCRIPTION
When the plugin is configured to use subdomains and the subdomains are configured outside of Wordpress, there is no way to know the language subdomain when the request is proxied to Prerender. In this case we now can use the Transifex-Lang header to pass the correct language code to wordpress.