### PR TITLE
TX-8822 Add hook for handling content's url rewrites

### DIFF
--- a/includes/lib/transifex-live-integration-rewrite.php
+++ b/includes/lib/transifex-live-integration-rewrite.php
@@ -190,7 +190,7 @@ class Transifex_Live_Integration_Rewrite {
 	 */
 
 	function pre_post_link_hook( $permalink, $post, $leavename ) {
-		if ( !Transifex_Live_Integration_Validators::is_permalink_ok( $permalink ) ) {
+	  if ( !Transifex_Live_Integration_Validators::is_permalink_ok( $permalink ) ) {
 			return $permalink;
 		}
 		$lang = $this->lang;
@@ -331,18 +331,19 @@ class Transifex_Live_Integration_Rewrite {
 	 * @param string $string The string to filter
 	 * @return string The filtered string
 	 */
-	 function the_content_hook( $string) {
- 		
- 		// Regular expression that extracts all urls from a string
- 		preg_match_all('#\b(https|http)?://[^,\s()<>]+(?:\([\w\d]+\)|([^,[:punct:]\s]|/))#', $string, $matchArray);
- 		// Iterate through all links, rewrite when needed
- 		foreach($matchArray as $match){
- 				if ( !Transifex_Live_Integration_Validators::is_hard_link_ok( $match[0] ) ) {
- 				    continue;
- 				}
- 		    $retlink = $this->reverse_hard_link( $this->lang, $match[0], $this->languages_map, $this->source_language, $this->rewrite_pattern );
- 				$string = str_replace($match[0], $retlink, $string);
- 		}
- 		return $string;
- 	}
+	function the_content_hook( $string) {
+	  // Regular expression that extracts all urls from a string
+	  $regexp = "<a\s[^>]*href=(\"??)([^\" >]*?)\\1[^>]*>(.*)<\/a>";
+	  preg_match_all("/$regexp/siU", $string, $matchArray);
+	  // Iterate through all links, rewrite when needed
+	  foreach($matchArray[2] as $match){
+	    if ( !Transifex_Live_Integration_Validators::is_hard_link_ok( $match ) ) {
+	        continue;
+	      }
+	    $retlink = $this->reverse_hard_link( $this->lang, $match, $this->languages_map, $this->source_language, $this->rewrite_pattern );
+	    $string = str_replace($match, $retlink, $string);
+		}
+		return $string;
+	}
+
 }

--- a/includes/lib/transifex-live-integration-rewrite.php
+++ b/includes/lib/transifex-live-integration-rewrite.php
@@ -325,5 +325,24 @@ class Transifex_Live_Integration_Rewrite {
 		$retlink = $this->reverse_hard_link( $this->lang, $url, $this->languages_map, $this->source_language, $this->rewrite_pattern );
 		return $retlink;
 	}
-
+	
+	/*
+	 * WP the_content_hook hook, filters links using the the_content function
+	 * @param string $string The string to filter
+	 * @return string The filtered string
+	 */
+	 function the_content_hook( $string) {
+ 		
+ 		// Regular expression that extracts all urls from a string
+ 		preg_match_all('#\b(https|http)?://[^,\s()<>]+(?:\([\w\d]+\)|([^,[:punct:]\s]|/))#', $string, $matchArray);
+ 		// Iterate through all links, rewrite when needed
+ 		foreach($matchArray as $match){
+ 				if ( !Transifex_Live_Integration_Validators::is_hard_link_ok( $match[0] ) ) {
+ 				    continue;
+ 				}
+ 		    $retlink = $this->reverse_hard_link( $this->lang, $match[0], $this->languages_map, $this->source_language, $this->rewrite_pattern );
+ 				$string = str_replace($match[0], $retlink, $string);
+ 		}
+ 		return $string;
+ 	}
 }

--- a/includes/lib/transifex-live-integration-rewrite.php
+++ b/includes/lib/transifex-live-integration-rewrite.php
@@ -190,7 +190,7 @@ class Transifex_Live_Integration_Rewrite {
 	 */
 
 	function pre_post_link_hook( $permalink, $post, $leavename ) {
-	  if ( !Transifex_Live_Integration_Validators::is_permalink_ok( $permalink ) ) {
+		if ( !Transifex_Live_Integration_Validators::is_permalink_ok( $permalink ) ) {
 			return $permalink;
 		}
 		$lang = $this->lang;
@@ -327,21 +327,21 @@ class Transifex_Live_Integration_Rewrite {
 	}
 	
 	/*
-	 * WP the_content_hook hook, filters links using the the_content function
-	 * @param string $string The string to filter
-	 * @return string The filtered string
-	 */
+	* WP the_content_hook hook, filters links using the the_content function
+	* @param string $string The string to filter
+	* @return string The filtered string
+	*/
 	function the_content_hook( $string) {
-	  // Regular expression that extracts all urls from a string
-	  $regexp = "<a\s[^>]*href=(\"??)([^\" >]*?)\\1[^>]*>(.*)<\/a>";
-	  preg_match_all("/$regexp/siU", $string, $matchArray);
-	  // Iterate through all links, rewrite when needed
-	  foreach($matchArray[2] as $match){
-	    if ( !Transifex_Live_Integration_Validators::is_hard_link_ok( $match ) ) {
-	        continue;
-	      }
-	    $retlink = $this->reverse_hard_link( $this->lang, $match, $this->languages_map, $this->source_language, $this->rewrite_pattern );
-	    $string = str_replace($match, $retlink, $string);
+		// Regular expression that extracts all urls from a string
+		$regexp = "<a\s[^>]*href=(\"??)([^\" >]*?)\\1[^>]*>(.*)<\/a>";
+		preg_match_all("/$regexp/siU", $string, $matchArray);
+		// Iterate through all links, rewrite when needed
+		foreach($matchArray[2] as $match){
+			if ( !Transifex_Live_Integration_Validators::is_hard_link_ok( $match ) ) {
+				continue;
+			}
+			$retlink = $this->reverse_hard_link( $this->lang, $match, $this->languages_map, $this->source_language, $this->rewrite_pattern );
+			$string = str_replace($match, $retlink, $string);
 		}
 		return $string;
 	}

--- a/transifex-live-integration-main.php
+++ b/transifex-live-integration-main.php
@@ -148,6 +148,7 @@ class Transifex_Live_Integration {
 				add_filter( 'month_link', [$rewrite, 'month_link_hook' ], 10, 3 );
 				add_filter( 'year_link', [$rewrite, 'year_link_hook' ], 10, 2 );
 				add_filter( 'home_url', [$rewrite, 'home_url_hook' ] );
+				add_filter( 'the_content', [$rewrite, 'the_content_hook' ], 10);
 			}
 		}
 		$subdirectory = Transifex_Live_Integration_Static_Factory::create_subdirectory( $settings, $rewrite_options );


### PR DESCRIPTION
Problem
--------
When using the subdirectory SEO settings, the plugin uses hooks to rewrite urls to the correct language (ex. from `/post/hello-world` to `/el/post/hello-world`). This functionality is not working for the content of a page / post, since the appropriate hook is missing.

Steps to reproduce the bug
-------
In the backend:
- Enable subdirectories SEO options
- Add a couple of languages to support
- Edit a page to include a link to itself.

In the frontend:
- Visit the above page
- Using the language picker update the language
- Ensure that the content has been updated to the new language setting.
- Click the link to itself.
- Check that previous language setting has been updated to default.

Solution
--------
Add a hook to access a page / post content. Iterate through the html, extract all urls, then filter them to reflect the correct language.