### PR TITLE
Add filter for custom rewrite rules

### DIFF
--- a/includes/lib/transifex-live-integration-subdirectory.php
+++ b/includes/lib/transifex-live-integration-subdirectory.php
@@ -167,7 +167,33 @@ class Transifex_Live_Integration_Subdirectory {
 		$this->post_permastruct = $pp;
 		$rr = Transifex_Live_Integration_Generate_Rewrite_Rules::generate_rewrite_rules( $pp, EP_PERMALINK, true, false, false, true );
 		$rewrite = array_merge( $rr, $rules );
+		
+		// Handle custom post types from custom filter
+		$custom_rewrite = $this->custom_type_rules_hook();
+		$rewrite = array_merge( $custom_rewrite, $rewrite);
+		
 		return $rewrite;
+	}
+	
+	/**
+	 * Callback function to the WP page_rewrite_rules
+	 *
+	 * It applies a custom filter, allowing 3rd party modules to add their own
+	 * permalink rewrite rules.
+	 *
+	 * @return array Returns custom rewrite rules
+	 */
+	 function custom_type_rules_hook(){
+		// Get custom rules from 3rd party module, if our own filter is being used
+		$custom_types_array = apply_filters('transifex_generate_rewrite_rules', $custom_types_array);
+		$rewrite_array = array();
+		foreach($custom_types_array as $custom_type_regex => $custom_type_action){
+			// Replace the lang placeholder with the language regex for this configuation
+			$custom_type_regex = str_replace("%lang%", $this->languages_regex, $custom_type_regex);
+			// Add permalink to array
+			$rewrite_array[$custom_type_regex] = $custom_type_action;
+		}
+		return $rewrite_array;
 	}
 
 	/**


### PR DESCRIPTION
Added the ability for custom rewrite rules, through a custom filter.

Right now permalink rewrites only support default pages and posts, and not custom types. We have implemented a custom filter `transifex_generate_rewrite_rules`, that enables the user to insert its own custom type permalinks, through a regular expression.

As an example, the code below should be added in a new module, and will create permalinks for a custom type page named transifex.

```
// Filter that implements our custom rewrite rules filter
add_filter('transifex_generate_rewrite_rules', 'custom_types_rewrite', 10 ,1);

/**
 * Callback function to transifex_generate_rewrite_rules filter
 *
 * The custom function used by the filter needs to return an associate array in
 * the followinng format:
 * [regular expression] => application query 
 *
 * Please note that the regular expression must include the %lang% placholder, and
 * the application query should inlcude the lang parameter. Additionally, this function can return multiple permalink rules.
 *
 * Example: For the custom type with the permalink '/transifex/page-name', the
 * rewrite rule can be
 * '%lang%/transifex/([^/]+)(?:/([0-9]+))?/?$' => 'index.php?lang=$matches[1]&transifex=$matches[2]'
 *
 * @return array Returns custom rewrite rules array
 */
function custom_types_rewrite(){
	return array(
	    '%lang%/transifex/([^/]+)(?:/([0-9]+))?/?$' => 'index.php?lang=$matches[1]&transifex=$matches[2]'
	);
}
```