### PR TITLE
Add additional filter hooks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,16 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 
 The WP-Translations project for plugin translations can be found [here](https://www.transifex.com/wp-translations/transifex-live/transifex-live/).
 
+== Tips for developers ==
+
+* The Transifex Live plugin uses Wordpress hooks to manipulate the links found in your website's content, so they always point to the appropriate language. If you use custom post types (or one of your plugins does) that emits the 'the_content' filter, our code might not be triggered.
+
+For those cases, it is recommended to manually trigger our custom filter 'tx_link' before you return your content, as seen in the example below: 
+
+Ex. $updated_content = apply_filters('tx_link', $original_content);
+
+* It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
+
 == Changelog ==
 
 = 1.3.15 =

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,16 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 2. screenshot-2.jpg
 3. screenshot-3.jpg
 
+== Tips for developers ==
+
+The Transifex Live plugin uses Wordpress hooks to manipulate the links found in your website's content, so they always point to the appropriate language. If you use custom post types (or one of your plugins does) that emits the 'the_content' filter, our code might not be triggered.
+
+For those cases, it is recommended to manually trigger our custom filter 'tx_link' before you return your content, as seen in the example below: 
+
+Ex. $updated_content = apply_filters('tx_link', $original_content);
+
+It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
+
 == Changelog ==
 
 = 1.3.15 =

--- a/transifex-live-integration-main.php
+++ b/transifex-live-integration-main.php
@@ -149,6 +149,9 @@ class Transifex_Live_Integration {
 				add_filter( 'year_link', [$rewrite, 'year_link_hook' ], 10, 2 );
 				add_filter( 'home_url', [$rewrite, 'home_url_hook' ] );
 				add_filter( 'the_content', [$rewrite, 'the_content_hook' ], 10);
+				add_filter( 'widget_text', [$rewrite, 'the_content_hook' ], 10);
+				// Add filter for custom content that is not triggered by any other hook
+				add_filter('tx_link',  [ $rewrite,'the_content_hook'], 10 ,1);
 			}
 		}
 		$subdirectory = Transifex_Live_Integration_Static_Factory::create_subdirectory( $settings, $rewrite_options );


### PR DESCRIPTION
Enable support for the widget hook. Add a `tx_link` filter hook, to be used when plugins manipulate and return content that bypasses default hooks and actions (like 'the_content' that is normally used to add language info to all content links).