### PR TITLE
Remove Grunt tests from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,6 @@ before_script:
   - echo "$(curl -fsSL https://gist.githubusercontent.com/matthewjackowski/3b26061241545564ae8d/raw/install-wp-tests.sh)" | sudo tee ./install-wp-tests.sh > /dev/null
   - bash ./install-wp-tests.sh test root '' localhost $WP_VERSION
   - sudo service apache2 restart
-  - sudo echo $'[https://www.transifex.com]\nhostname = https://www.transifex.com\nusername = '"$TX_USERNAME"$'\npassword = '"$TX_PASSWORD"$'\ntoken =' > ~/.transifexrc
-  - sudo npm install
-  - sudo npm install -g grunt-cli
 
 
 script:
@@ -60,7 +57,6 @@ script:
   - pyenv global 2.7.10
   - pip install transifex-client
   - codecept run
-  - grunt tx-push
   - sudo chmod +x ./wp-plugin-deploy.sh
   - if [ $TRAVIS_BRANCH = 'master' ]; then ./wp-plugin-deploy.sh; fi
 


### PR DESCRIPTION
There are some grunt tests that run on master / devel branches, which check the integration between a Wordpress site and Transifex client. These tests stopped working recently, due to changes in the used credentials, but they should be removed nonetheless, since they are out of the plugin's scope.