### PR TITLE
Fix subfolder url rewritting for external domains

### DIFF
--- a/includes/lib/transifex-live-integration-rewrite.php
+++ b/includes/lib/transifex-live-integration-rewrite.php
@@ -162,7 +162,7 @@ class Transifex_Live_Integration_Rewrite {
 		if ( empty( $lang ) || empty( $languages_map ) ) {
 			return $link;
 		}
-                elseif ( !in_array( $lang, array_values( $languages_map ) ) || $source_lang == $lang ) {
+		elseif ( !in_array( $lang, array_values( $languages_map ) ) || $source_lang == $lang ) {
 			return $link;
 		}
 
@@ -170,13 +170,19 @@ class Transifex_Live_Integration_Rewrite {
 		if ( count( $m ) > 1 ) {
 			$link = str_replace( $m[1], $lang, $m[0] );
 		} else {
-			/* Check if the path starts with the language code,
-			 * otherwise prepend it. */
-			$parsed = parse_url( $link );
-			if ( substr($parsed['path'], 1, strlen($lang))  != $lang ) {
-				$parsed['path'] = '/' . $lang . $parsed['path'];
+			$site_host = parse_url(site_url())['host'];
+			$parsed_url = parse_url($link);
+			$link_host = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+			// change only wordpress links - not links reffering to other domains
+			if ( $link_host === $site_host ) {
+				/* Check if the path starts with the language code,
+				* otherwise prepend it. */
+				$parsed = parse_url( $link );
+				if ( substr($parsed['path'], 1, strlen($lang))  != $lang ) {
+					$parsed['path'] = '/' . $lang . $parsed['path'];
+				}
+				$link = Transifex_Live_Integration_Util::unparse_url( $parsed );
 			}
-			$link = Transifex_Live_Integration_Util::unparse_url( $parsed );
 		}
 		return $link;
 	}


### PR DESCRIPTION
Related to [TX-10761: URLs that are included in a page but belong to a different domain should be excluded from subdirectories](https://transifex.atlassian.net/secure/RapidBoard.jspa?rapidView=56&modal=detail&selectedIssue=TX-10761)

Problem and/or solution
------------------------
The problematic behaviour is that URLs that are included as content but
belong to a different domain are not excluded from subdirectories url
rewritting.
The fix introduces a check in the main function that does the url re-
writting (function reverse_hard_link, in
transifex-live-integration-rewrite.php) that validates the host part
of the url in every link processed to guarantee that we leave unchanged
URLs in different domains.

How to test
------------
* From WP admin UI in a sample post add a block of HTML content that 
contains links that point to both local or external links.
* From WP admin UI create a new (Appearance > Menus) that contains
both local and external links. Add the menu to some WP pages. 

Preview the above created links in the frontend selecting a translated 
language from the language selector.

**Important note:** The plugin does NOT support URL rewritting of partial
links (without a host part eg: '/test-page2')