### PR TITLE
Update php version to 7.2 on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
   on_failure: change
 
 php:
-  - 5.6
+  - 7.2
 
 env:
   - WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:80 WP_TEST_USER=test WP_TEST_USER_PASS=test
@@ -27,7 +27,7 @@ addons:
 before_script:
   - sudo whoami
   - pwd
-  - composer global require "codeception/codeception:*"
+  - COMPOSER_MEMORY_LIMIT=-1 composer global require "codeception/codeception:*"
   - sudo ln -s /home/travis/.config/composer/vendor/bin/codecept /usr/local/bin/codecept
   - sudo apt-add-repository multiverse && sudo apt-get update
   - sudo add-apt-repository -y ppa:chris-lea/node.js


### PR DESCRIPTION
- Update the php version of TravisCI to 7.2.
- Run composer to require codeception without memory limit.