### PR TITLE
TX-12349 Update WP to the new version 5.4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 
 == Changelog ==
 
+= 1.3.21 =
+Update the latest tested WordPress version (5.4)
+
 = 1.3.20 =
 Update the latest tested WordPress version (5.3.2)
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ International SEO by Transifex
 Contributors: txmatthew, ThemeBoy, brooksx
 Tags: transifex, localize, localization, multilingual, international, SEO
 Requires at least: 3.5.2
-Tested up to: 5.3.2
-Stable tag: 1.3.20
+Tested up to: 5.4
+Stable tag: 1.3.21
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
 
 == Changelog ==
+
+= 1.3.21 =
+Update the latest tested WordPress version (5.4)
 
 = 1.3.20 =
 Update the latest tested WordPress version (5.3.2)

--- a/transifex-live-integration.php
+++ b/transifex-live-integration.php
@@ -5,13 +5,13 @@
  *
  * @link    http://docs.transifex.com/developer/integrations/wordpress
  * @package TransifexLiveIntegration
- * @version 1.3.20
+ * @version 1.3.21
  *
  * @wordpress-plugin
  * Plugin Name:       International SEO by Transifex
  * Plugin URI:        http://docs.transifex.com/developer/integrations/wordpress
  * Description:       Translate your WordPress powered website using Transifex.
- * Version:           1.3.20
+ * Version:           1.3.21
  * License:           GNU General Public License
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       transifex-live-integration
@@ -75,7 +75,7 @@ if ( !defined( 'TRANSIFEX_LIVE_INTEGRATION_REGEX_PATTERN_CHECK_PATTERN' ) ) {
 }
 
 define( 'LANG_PARAM', 'lang' );
-$version = '1.3.20';
+$version = '1.3.21';
 
 require_once( dirname( __FILE__ ) . '/transifex-live-integration-main.php' );
 Transifex_Live_Integration::do_plugin( is_admin(), $version );


### PR DESCRIPTION
WP has announced a new release, 5.4, at the end of March 2020.
We need to make our plugin ready for that version.