### PR TITLE
Travis should run tests on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,3 @@
-branches:
-  only:
-    - master
-    - devel
-
 sudo: required
 dist: trusty
 language: php


### PR DESCRIPTION
Remove the safelist check of the `branches` option in order for travis to run on all branches.