### PR TITLE
TX-12720 Update WP to the new version 5.5

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,13 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 
 == Changelog ==
 
+= 1.3.23 =
+Update the latest tested WordPress version (5.5)
+
+= 1.3.22 =
+Fix a bug related with the generation of the HTTP version of the links
+that have the hreflang attribute.
+
 = 1.3.21 =
 Update the latest tested WordPress version (5.4)
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ International SEO by Transifex
 Contributors: txmatthew, ThemeBoy, brooksx
 Tags: transifex, localize, localization, multilingual, international, SEO
 Requires at least: 3.5.2
-Tested up to: 5.4
-Stable tag: 1.3.22
+Tested up to: 5.5
+Stable tag: 1.3.23
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
 
 == Changelog ==
+
+= 1.3.23 =
+Update the latest tested WordPress version (5.5)
 
 = 1.3.22 =
 Fix a bug related with the generation of the HTTP version of the links

--- a/transifex-live-integration.php
+++ b/transifex-live-integration.php
@@ -5,13 +5,13 @@
  *
  * @link    http://docs.transifex.com/developer/integrations/wordpress
  * @package TransifexLiveIntegration
- * @version 1.3.22
+ * @version 1.3.23
  *
  * @wordpress-plugin
  * Plugin Name:       International SEO by Transifex
  * Plugin URI:        http://docs.transifex.com/developer/integrations/wordpress
  * Description:       Translate your WordPress powered website using Transifex.
- * Version:           1.3.22
+ * Version:           1.3.23
  * License:           GNU General Public License
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       transifex-live-integration
@@ -75,7 +75,7 @@ if ( !defined( 'TRANSIFEX_LIVE_INTEGRATION_REGEX_PATTERN_CHECK_PATTERN' ) ) {
 }
 
 define( 'LANG_PARAM', 'lang' );
-$version = '1.3.22';
+$version = '1.3.23';
 
 require_once( dirname( __FILE__ ) . '/transifex-live-integration-main.php' );
 Transifex_Live_Integration::do_plugin( is_admin(), $version );


### PR DESCRIPTION
WP released a new version, 5.5, in August 11th 2020.
We needed to make our plugin ready for that version as well.