### PR TITLE
Support for wordpress 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-sudo: required
+os:
+  - linux
+
 dist: trusty
 language: php
 
@@ -12,7 +14,7 @@ php:
 env:
   - WP_PROJECT_TYPE=plugin WP_VERSION=latest WP_MULTISITE=0 WP_TEST_URL=http://localhost:80 WP_TEST_USER=test WP_TEST_USER_PASS=test
 
-matrix:
+jobs:
   allow_failures:
     - php: nightly
 
@@ -22,7 +24,7 @@ addons:
 before_script:
   - sudo whoami
   - pwd
-  - COMPOSER_MEMORY_LIMIT=-1 composer global require "codeception/module-asserts:1.2"
+  - COMPOSER_MEMORY_LIMIT=-1 composer global require "codeception/module-asserts:1.3"
   - COMPOSER_MEMORY_LIMIT=-1 composer global require "codeception/codeception:4.1.5"
   - sudo ln -s /home/travis/.config/composer/vendor/bin/codecept /usr/local/bin/codecept
   - sudo apt-add-repository multiverse && sudo apt-get update

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 
 == Changelog ==
 
+= 1.3.24 =
+Update the latest tested WordPress version (5.6)
+
 = 1.3.23 =
 Update the latest tested WordPress version (5.5)
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ International SEO by Transifex
 Contributors: txmatthew, ThemeBoy, brooksx
 Tags: transifex, localize, localization, multilingual, international, SEO
 Requires at least: 3.5.2
-Tested up to: 5.5
-Stable tag: 1.3.23
+Tested up to: 5.6
+Stable tag: 1.3.24
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
 
 == Changelog ==
+
+= 1.3.24 =
+Update the latest tested WordPress version (5.6)
 
 = 1.3.23 =
 Update the latest tested WordPress version (5.5)

--- a/transifex-live-integration.php
+++ b/transifex-live-integration.php
@@ -5,13 +5,13 @@
  *
  * @link    http://docs.transifex.com/developer/integrations/wordpress
  * @package TransifexLiveIntegration
- * @version 1.3.23
+ * @version 1.3.24
  *
  * @wordpress-plugin
  * Plugin Name:       International SEO by Transifex
  * Plugin URI:        http://docs.transifex.com/developer/integrations/wordpress
  * Description:       Translate your WordPress powered website using Transifex.
- * Version:           1.3.23
+ * Version:           1.3.24
  * License:           GNU General Public License
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       transifex-live-integration
@@ -75,7 +75,7 @@ if ( !defined( 'TRANSIFEX_LIVE_INTEGRATION_REGEX_PATTERN_CHECK_PATTERN' ) ) {
 }
 
 define( 'LANG_PARAM', 'lang' );
-$version = '1.3.23';
+$version = '1.3.24';
 
 require_once( dirname( __FILE__ ) . '/transifex-live-integration-main.php' );
 Transifex_Live_Integration::do_plugin( is_admin(), $version );


### PR DESCRIPTION
The next release of Wordpress 5.6, is scheduled for 08 December 2020. We need to make our plugin support this version.

We also update:
- Travis to fix all the building warnings.
- Update `codeception/module-asserts` to 1.3 to tackle [this issue](https://github.com/Codeception/Codeception/issues/5959).