### PR TITLE
Fix deprecation warnings

### DIFF
--- a/includes/lib/transifex-live-integration-hreflang.php
+++ b/includes/lib/transifex-live-integration-hreflang.php
@@ -105,7 +105,7 @@ class Transifex_Live_Integration_Hreflang {
 			if (count($href_link_parts) && ($href_link_parts[0] === 'http' || $href_link_parts[0] === 'https')) {
 				$protocol = Transifex_Live_Integration_Util::get_http_requested_protocol();
 				$href_link_parts[0] = $protocol;
-				$arr['href'] = implode($href_link_parts, ':');
+				$arr['href'] = implode(':', $href_link_parts);
 			} else {
 				$arr['href'] = $url_map[$language];
 			}

--- a/includes/transifex-live-integration-util.php
+++ b/includes/transifex-live-integration-util.php
@@ -91,7 +91,7 @@ class Transifex_Live_Integration_Util {
 
 		$is_bot = self::is_bot_type( $req_user_agent, $bot_types_escaped );
 		$is_whitelisted = ($is_bot) ? true : self::is_whitelist_name( $req_user_agent, $whitelist_names_escaped );
-		$has_escaped_fragment = ($is_whitelisted) ? true : ($req_escaped_fragment) ? true : false;
+		$has_escaped_fragment = ($is_whitelisted) ? true : (($req_escaped_fragment) ? true : false);
 		$prerender_ok = ($has_escaped_fragment) ? true : self::is_prerender_req( self::get_user_agent() );
 
 		return $prerender_ok;
@@ -117,7 +117,7 @@ class Transifex_Live_Integration_Util {
 			} else {
 				array_unshift($dots, $lang);
 			}
-			$host = implode($dots, '.');
+			$host = implode('.', $dots);
 			$url_parts['host'] = $host;
 			$page_url = Transifex_Live_Integration_Util::unparse_url($url_parts);
 		}

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 
 == Changelog ==
 
+= 1.3.25 =
+Fix deprecated implode and unparenthesized warnings
+
 = 1.3.24 =
 Update the latest tested WordPress version (5.6)
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: txmatthew, ThemeBoy, brooksx
 Tags: transifex, localize, localization, multilingual, international, SEO
 Requires at least: 3.5.2
 Tested up to: 5.6
-Stable tag: 1.3.24
+Stable tag: 1.3.25
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
 
 == Changelog ==
+
+= 1.3.25 =
+Fix deprecated implode and unparenthesized warnings
 
 = 1.3.24 =
 Update the latest tested WordPress version (5.6)

--- a/transifex-live-integration.php
+++ b/transifex-live-integration.php
@@ -5,13 +5,13 @@
  *
  * @link    http://docs.transifex.com/developer/integrations/wordpress
  * @package TransifexLiveIntegration
- * @version 1.3.24
+ * @version 1.3.25
  *
  * @wordpress-plugin
  * Plugin Name:       International SEO by Transifex
  * Plugin URI:        http://docs.transifex.com/developer/integrations/wordpress
  * Description:       Translate your WordPress powered website using Transifex.
- * Version:           1.3.24
+ * Version:           1.3.25
  * License:           GNU General Public License
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       transifex-live-integration
@@ -75,7 +75,7 @@ if ( !defined( 'TRANSIFEX_LIVE_INTEGRATION_REGEX_PATTERN_CHECK_PATTERN' ) ) {
 }
 
 define( 'LANG_PARAM', 'lang' );
-$version = '1.3.24';
+$version = '1.3.25';
 
 require_once( dirname( __FILE__ ) . '/transifex-live-integration-main.php' );
 Transifex_Live_Integration::do_plugin( is_admin(), $version );


### PR DESCRIPTION
Removes the following deprecation messages:

- Deprecated: implode(): Passing glue string after array is deprecated. Swap the parameters
- Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` 