### PR TITLE
Fix hreflang URL

### DIFF
--- a/includes/lib/transifex-live-integration-hreflang.php
+++ b/includes/lib/transifex-live-integration-hreflang.php
@@ -130,6 +130,7 @@ class Transifex_Live_Integration_Hreflang {
 		$source = $this->settings['source_language'];
 		$site_url_slash_maybe = site_url();
 		$site_url = rtrim( $site_url_slash_maybe, '/' ) . '/';
+		$source_url_path = ltrim( $source_url_path, '/' );
 		$unslashed_source_url = $site_url . $source_url_path;
 		$source_url = rtrim( $unslashed_source_url, '/' ) . '/';
 		$hreflang_out = '';
@@ -147,7 +148,6 @@ HREFLANG;
 		echo $hreflang_out;
 		return true;
 	}
-
 }
 
 ?>

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 
 == Changelog ==
 
+= 1.3.27 =
+Fix hreflang
+
 = 1.3.26 =
 Skip static when calling prerender
 

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,9 @@ It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API
 
 == Changelog ==
 
+= 1.3.27 =
+Fix hreflang
+
 = 1.3.26 =
 Skip static when calling prerender
 
@@ -185,4 +188,3 @@ Custom language picker color options removed
 
 = 1.0.0 =
 Full release.  Restructured plugin to follow boilerplate.  Added unit tests.
-

--- a/transifex-live-integration.php
+++ b/transifex-live-integration.php
@@ -5,13 +5,13 @@
  *
  * @link    http://docs.transifex.com/developer/integrations/wordpress
  * @package TransifexLiveIntegration
- * @version 1.3.26
+ * @version 1.3.27
  *
  * @wordpress-plugin
  * Plugin Name:       International SEO by Transifex
  * Plugin URI:        http://docs.transifex.com/developer/integrations/wordpress
  * Description:       Translate your WordPress powered website using Transifex.
- * Version:           1.3.26
+ * Version:           1.3.27
  * License:           GNU General Public License
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       transifex-live-integration
@@ -75,7 +75,7 @@ if ( !defined( 'TRANSIFEX_LIVE_INTEGRATION_REGEX_PATTERN_CHECK_PATTERN' ) ) {
 }
 
 define( 'LANG_PARAM', 'lang' );
-$version = '1.3.26';
+$version = '1.3.27';
 
 require_once( dirname( __FILE__ ) . '/transifex-live-integration-main.php' );
 Transifex_Live_Integration::do_plugin( is_admin(), $version );


### PR DESCRIPTION
WP plugin causes hreflang URL to output an extra forward slashes when a language is applied on a URL with a path