### PR TITLE
Replace Craft-csm doc links with Intercom doc links

### DIFF
--- a/includes/admin/transifex-live-integration-admin-template.php
+++ b/includes/admin/transifex-live-integration-admin-template.php
@@ -39,12 +39,12 @@
 		<tr>
 			<td>
 				<label for="transifex_live_settings_url_options">
-					<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_none" name="transifex_live_settings[url_options_none]" value="1" <?php echo $url_options_none ?>><?php _e( 'Disabled – Just add the Transifex Live JavaScript snippet to my site. <a target="_blank" href="http://docs.transifex.com/integrations/wordpress/#disabled"><b>Learn more</b></a>.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
-					<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_subdirectory" name="transifex_live_settings[url_options_subdirectory]" value="1" <?php echo $url_options_subdirectory ?>><?php _e( 'Subdirectory – Create new language subdirectories through the plugin, e.g. <code>http://www.example.com/fr/</code>. <a target="_blank" href="http://docs.transifex.com/integrations/wordpress/#subdirectories"><b>Learn more</b></a>.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
-					<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_subdomain" name="transifex_live_settings[url_options_subdomain]" value="1" <?php echo $url_options_subdomain ?>><?php _e( 'Subdomain – Point the plugin to existing language subdomains, e.g. <code>http://fr.example.com</code>. <a target="_blank" href="http://docs.transifex.com/integrations/wordpress/#subdomains"><b>Learn more</b></a>.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
+					<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_none" name="transifex_live_settings[url_options_none]" value="1" <?php echo $url_options_none ?>><?php _e( 'Disabled – Just add the Transifex Live JavaScript snippet to my site. <a target="_blank" href="https://help.transifex.com/en/articles/6261241-wordpress#h_c053feadce"><b>Learn more</b></a>.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
+					<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_subdirectory" name="transifex_live_settings[url_options_subdirectory]" value="1" <?php echo $url_options_subdirectory ?>><?php _e( 'Subdirectory – Create new language subdirectories through the plugin, e.g. <code>http://www.example.com/fr/</code>. <a target="_blank" href="https://help.transifex.com/en/articles/6261241-wordpress#h_c053feadce"><b>Learn more</b></a>.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
+					<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_subdomain" name="transifex_live_settings[url_options_subdomain]" value="1" <?php echo $url_options_subdomain ?>><?php _e( 'Subdomain – Point the plugin to existing language subdomains, e.g. <code>http://fr.example.com</code>. <a target="_blank" href="https://help.transifex.com/en/articles/6261241-wordpress#h_c053feadce"><b>Learn more</b></a>.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
 					<input type="hidden" id="transifex_live_settings_url_options" name="transifex_live_settings[url_options]" value="<?php echo $url_options ?>" >
 				</label>
-				<p class="description"><?php _e( '<b>Note:</b> When you choose the Subdirectory or Subdomain options, the plugin will automatically <a target="_blank" href="http://docs.transifex.com/integrations/wordpress/#hreflang-tag"><b>add hreflang tags</b></a> to the header of your site.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
+				<p class="description"><?php _e( '<b>Note:</b> When you choose the Subdirectory or Subdomain options, the plugin will automatically <a target="_blank" href="https://help.transifex.com/en/articles/6261241-wordpress#h_c053feadce"><b>add hreflang tags</b></a> to the header of your site.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
 			</td></tr></table>
 	<table class="form-table">
 		<tr class="custom-urls-settings hide-if-js">
@@ -89,7 +89,7 @@
 					<?php Transifex_Live_Integration_Admin_Util::render_url_options( $rewrite_options_array ); ?>
 				</table>
 				</p>
-				<p class="url-structure-subdirectory description"><?php _e( 'Having trouble getting language/region-specific URLs working? <a target="_blank" href="http://docs.transifex.com/integrations/wordpress/#troubleshooting-tips">Check out our additional troubleshooting tips!', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></a></p>
+				<p class="url-structure-subdirectory description"><?php _e( 'Having trouble getting language/region-specific URLs working? <a target="_blank" href="https://help.transifex.com/en/articles/6261241-wordpress#h_d6f3378e42">Check out our additional troubleshooting tips!', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></a></p>
 			</td></tr>
 		<tr class="prerender-options hide-if-js">
 			<th><?php _e( 'Prerender for Crawlers', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></th>
@@ -122,7 +122,7 @@
 							<input name="transifex_live_settings[generic_bot_types]" type="text" id="transifex_live_settings_generic_bot_types" value="<?php echo $settings['generic_bot_types']; ?>" class="regular-text" placeholder="<?php _e( 'Regex list of crawler type keywords.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?>">
 						</p>
 					</div>
-					<p class="description"><?php _e( 'Important so crawler and bots can see your translated content <a target="_blank" href="https://docs.transifex.com/integrations/wordpress#helping-bots-read-translations">Check out our docs for details.</a>', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
+					<p class="description"><?php _e( 'Important so crawler and bots can see your translated content <a target="_blank" href="https://help.transifex.com/en/articles/6261241-wordpress#h_9fc24903e0">Check out our docs for details.</a>', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
 				</div>
 			</td></tr>
 		</tbody>
@@ -144,7 +144,7 @@
 	<p class="submit"><input disabled="true" type="submit" name="submit" id="transifex_live_submit" class="button button-primary" value="<?php _e( 'Save Changes', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?>"></p>
 </form>
 <p>
-	<a href="http://docs.transifex.com/integrations/wordpress/" target="_blank" ><?php _e( 'Plugin documentation', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></a> | <?php _e( 'Thank you for using Transifex!', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?>
+	<a href="https://help.transifex.com/en/articles/6261241-wordpress" target="_blank" ><?php _e( 'Plugin documentation', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></a> | <?php _e( 'Thank you for using Transifex!', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?>
 	</a>
 </p>
 </div>

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 
 == Description ==
 
-The Transifex International SEO is a WordPress plugin designed to be used with Transifex.  In order to use Transifex, you will need to [sign up here for an account](https://www.transifex.com/signup/?utm_source=github&utm_medium=web&utm_campaign=tx-live-wp-plugin). Please note that a Transifex Live API key is required in order to use the plugin.  More information about how to obtain a key can be found in the [plugin documentation here](https://help.transifex.com/en/articles/6261241-wordpress) if you don't have a key yet.
+The Transifex International SEO is a WordPress plugin designed to be used with Transifex.  In order to use Transifex, you will need to [sign up here for an account](https://www.transifex.com/signup/?utm_source=github&utm_medium=web&utm_campaign=tx-live-wp-plugin). Please note that a Transifex Live API key is required in order to use the plugin.  More information about how to obtain a key can be found in the [plugin documentation here](https://help.transifex.com/en/articles/6261241-wordpress#h_2339ce4961) if you don't have a key yet.
 
 == Features ==
 

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,12 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 
 == Changelog ==
 
+= 1.3.29 =
+Update documentation urls
+
+= 1.3.28 =
+Update the latest tested WordPress version (6.0)
+
 = 1.3.27 =
 Fix hreflang
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@
 
 == Description ==
 
-The Transifex International SEO is a WordPress plugin designed to be used with Transifex.  In order to use Transifex, you will need to [sign up here for an account](https://www.transifex.com/signup/?utm_source=github&utm_medium=web&utm_campaign=tx-live-wp-plugin). Please note that a Transifex Live API key is required in order to use the plugin.  More information about how to obtain a key can be found in the [plugin documentation here](http://docs.transifex.com/integrations/wordpress/#getting-your-transifex-live-api-key/?utm_source=github&utm_medium=web&utm_campaign=tx-live-wp-plugin) if you don't have a key yet.
+The Transifex International SEO is a WordPress plugin designed to be used with Transifex.  In order to use Transifex, you will need to [sign up here for an account](https://www.transifex.com/signup/?utm_source=github&utm_medium=web&utm_campaign=tx-live-wp-plugin). Please note that a Transifex Live API key is required in order to use the plugin.  More information about how to obtain a key can be found in the [plugin documentation here](https://help.transifex.com/en/articles/6261241-wordpress) if you don't have a key yet.
 
 == Features ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: txmatthew, ThemeBoy, brooksx
 Tags: transifex, localize, localization, multilingual, international, SEO
 Requires at least: 3.5.2
 Tested up to: 6.0
-Stable tag: 1.3.28
+Stable tag: 1.3.29
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
 
 == Changelog ==
+
+= 1.3.29 =
+Update documentation urls
 
 = 1.3.28 =
 Update the latest tested WordPress version (6.0)

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ Translate your WordPress powered website using Transifex.
 
 This plugin is designed to be used with Transifex localization platform. There’s no need to create one language per post, insert language tags, or have multiple WordPress instances. Your site’s content is automatically detected and ready to be saved to the Transifex localization platform, where you can translate with the help of your existing translators, or order professional translations from Transifex partners.
 
-In order to use Transifex, you will need to [sign up here for an account](https://www.transifex.com/signup/?utm_source=wp-directory&utm_campaign=int-wp). This plugin also requires a Transifex Live API key. More information about how to obtain a key can be found in the [plugin documentation](http://docs.transifex.com/integrations/wordpress/#getting-your-transifex-live-api-key/?utm_source=wp-directory&utm_campaign=int-wp).
+In order to use Transifex, you will need to [sign up here for an account](https://www.transifex.com/signup/?utm_source=wp-directory&utm_campaign=int-wp). This plugin also requires a Transifex Live API key. More information about how to obtain a key can be found in the [plugin documentation](https://help.transifex.com/en/articles/6261241-wordpress#h_2339ce4961).
 
 Features:
 

--- a/transifex-live-integration.php
+++ b/transifex-live-integration.php
@@ -3,13 +3,13 @@
 /**
  * Translate your WordPress powered website using Transifex.
  *
- * @link    http://docs.transifex.com/developer/integrations/wordpress
+ * @link    https://help.transifex.com/en/articles/6261241-wordpress
  * @package TransifexLiveIntegration
  * @version 1.3.28
  *
  * @wordpress-plugin
  * Plugin Name:       International SEO by Transifex
- * Plugin URI:        http://docs.transifex.com/developer/integrations/wordpress
+ * Plugin URI:        https://help.transifex.com/en/articles/6261241-wordpress
  * Description:       Translate your WordPress powered website using Transifex.
  * Version:           1.3.28
  * License:           GNU General Public License

--- a/transifex-live-integration.php
+++ b/transifex-live-integration.php
@@ -5,13 +5,13 @@
  *
  * @link    https://help.transifex.com/en/articles/6261241-wordpress
  * @package TransifexLiveIntegration
- * @version 1.3.28
+ * @version 1.3.29
  *
  * @wordpress-plugin
  * Plugin Name:       International SEO by Transifex
  * Plugin URI:        https://help.transifex.com/en/articles/6261241-wordpress
  * Description:       Translate your WordPress powered website using Transifex.
- * Version:           1.3.28
+ * Version:           1.3.29
  * License:           GNU General Public License
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       transifex-live-integration
@@ -75,7 +75,7 @@ if ( !defined( 'TRANSIFEX_LIVE_INTEGRATION_REGEX_PATTERN_CHECK_PATTERN' ) ) {
 }
 
 define( 'LANG_PARAM', 'lang' );
-$version = '1.3.28';
+$version = '1.3.29';
 
 require_once( dirname( __FILE__ ) . '/transifex-live-integration-main.php' );
 Transifex_Live_Integration::do_plugin( is_admin(), $version );


### PR DESCRIPTION
Related to [CS-1331: Update documentation links (Craft CMS -> Intercom)](https://transifex.atlassian.net/browse/CS-1331)

We are migrating our Help Center from Craft CMS to Intercom. So, all links exposed to our users need to be updated accordingly