### PR TITLE
Support WP install in subdirectory

### DIFF
--- a/includes/admin/transifex-live-integration-admin-template.php
+++ b/includes/admin/transifex-live-integration-admin-template.php
@@ -38,6 +38,11 @@
 	<table class="form-table">
 		<tr>
 			<td>
+				<p><label for="transifex_live_settings_subdirectory_path"><?php _e( 'Wordpress is installed under a subdirectory e.g. <code>http://www.example.com/cms/</code>', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN); ?>
+				<input name="transifex_live_settings[subdirectory_path]" type="text" id="transifex_live_settings_subdirectory_path" value="<?php echo $settings['subdirectory_path']; ?>" class="regular-text" placeholder="<?php _e( 'Put your subdirectory path here.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN); ?>"></p>
+			</td></tr></table>
+		<tr>
+			<td>
 				<label for="transifex_live_settings_url_options">
 					<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_none" name="transifex_live_settings[url_options_none]" value="1" <?php echo $url_options_none ?>><?php _e( 'Disabled – Just add the Transifex Live JavaScript snippet to my site. <a target="_blank" href="https://help.transifex.com/en/articles/6261241-wordpress#h_c053feadce"><b>Learn more</b></a>.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
 					<p><input type="radio" disabled="true" id="transifex_live_settings_url_options_subdirectory" name="transifex_live_settings[url_options_subdirectory]" value="1" <?php echo $url_options_subdirectory ?>><?php _e( 'Subdirectory – Create new language subdirectories through the plugin, e.g. <code>http://www.example.com/fr/</code>. <a target="_blank" href="https://help.transifex.com/en/articles/6261241-wordpress#h_c053feadce"><b>Learn more</b></a>.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>

--- a/includes/admin/transifex-live-integration-admin.php
+++ b/includes/admin/transifex-live-integration-admin.php
@@ -241,6 +241,7 @@ class Transifex_Live_Integration_Admin {
 		$settings['transifex_live_settings']['rewrite_pattern'] = $rewrite_pattern;
 		$settings['transifex_live_settings']['languages_regex'] = $languages_regex;
 		$settings['transifex_live_settings']['languages'] = $languages;
+		$settings['transifex_live_settings']['subdirectory_path'] = $settings['transifex_live_settings']['subdirectory_path'];
 		if ( isset( $settings['transifex_live_settings'] ) ) {
 			update_option( 'transifex_live_settings', $settings['transifex_live_settings'] );
 		}
@@ -304,6 +305,7 @@ class Transifex_Live_Integration_Admin {
 		$settings['transifex_live_settings']['source_language'] = ( isset( $settings['transifex_live_settings']['source_language'] )) ? sanitize_text_field( $settings['transifex_live_settings']['source_language'] ) : '';
 		$settings['transifex_live_settings']['subdomain_pattern'] = ( isset( $settings['transifex_live_settings']['subdomain_pattern'] )) ? sanitize_text_field( $settings['transifex_live_settings']['subdomain_pattern'] ) : '';
 		$settings['transifex_live_settings']['subdirectory_pattern'] = ( isset( $settings['transifex_live_settings']['subdirectory_pattern'] )) ? sanitize_text_field( $settings['transifex_live_settings']['subdirectory_pattern'] ) : '';
+		$settings['transifex_live_settings']['subdirectory_path'] = ( isset( $settings['transifex_live_settings']['subdirectory_path'] )) ? sanitize_text_field( $settings['transifex_live_settings']['subdirectory_path'] ) : '';
 		$settings['transifex_live_settings']['rewrite_pattern'] = ( isset( $settings['transifex_live_settings']['rewrite_pattern'] )) ? sanitize_text_field( $settings['transifex_live_settings']['rewrite_pattern'] ) : '';
 		$settings['transifex_live_settings']['languages_regex'] = ( isset( $settings['transifex_live_settings']['languages_regex'] )) ? sanitize_text_field( $settings['transifex_live_settings']['languages_regex'] ) : '';
 		$settings['transifex_live_settings']['transifex_languages'] = ( isset( $settings['transifex_live_settings']['transifex_languages'] )) ? sanitize_text_field( stripslashes( $settings['transifex_live_settings']['transifex_languages'] ) ) : '';

--- a/includes/common/plugin-debug.php
+++ b/includes/common/plugin-debug.php
@@ -64,7 +64,7 @@ class Plugin_Debug
         }
     }
 
-    public function printLog() 
+    public static function printLog()
     {
         if (self::$debug_mode ) {
             echo ('<div id="miw_debug" class="transparent notranslate" style="width:90%;margin: 1em auto;padding: 10px 160px;text-align: left;z-index: 999;">' . "\n");

--- a/includes/transifex-live-integration-defaults.php
+++ b/includes/transifex-live-integration-defaults.php
@@ -117,6 +117,7 @@ class Transifex_Live_Integration_Defaults {
 			'languages' => '',
 			'hreflang' => false,
 			'url_options' => 1,
+			'subdirectory_path' => '',
 			'source_alias' => 'www',
 			'subdomain_pattern' => self::calc_default_subdomain('www'),
 			'subdirectory_pattern' => self::calc_default_subdirectory(),

--- a/transifex-live-integration-main.php
+++ b/transifex-live-integration-main.php
@@ -130,6 +130,7 @@ class Transifex_Live_Integration {
 		$rewrite = Transifex_Live_Integration_Static_Factory::create_rewrite( $settings, $rewrite_options );
 		($rewrite) ? Plugin_Debug::logTrace( 'rewrite created' ) : Plugin_Debug::logTrace( 'rewrite skipped' );
 		if ( $rewrite ) {
+			// add_action( 'parse_query', [ $rewrite, 'parse_query_hook' ] );
 			// check for TDK enabled
 			if (isset( $settings['enable_tdk'] )) {
 				add_shortcode( 'get_language_url', [$rewrite,'get_language_url'] );
@@ -139,9 +140,9 @@ class Transifex_Live_Integration {
 			if ( isset( $rewrite_options['add_rewrites_reverse_template_links'] ) ) {
 				Plugin_Debug::logTrace( 'adding reverse template links' );
 				add_action( 'wp', [ $rewrite, 'wp_hook' ] );
-				add_filter( 'pre_post_link', [$rewrite, 'pre_post_link_hook' ], 10, 3 );
+  			add_filter( 'pre_post_link', [$rewrite, 'pre_post_link_hook' ], 10, 3 );
 				add_filter( 'term_link', [$rewrite, 'term_link_hook' ], 10, 3 );
-				add_filter( 'post_link', [$rewrite, 'term_link_hook' ], 10, 3 );
+				add_filter( 'post_link', [$rewrite, 'post_link_hook' ], 10, 3 );
 				add_filter( 'post_type_archive_link', [$rewrite, 'post_type_archive_link_hook' ], 10, 2 );
 				add_filter( 'page_link', [$rewrite, 'page_link_hook' ], 10, 3 );
 				add_filter( 'day_link', [$rewrite, 'day_link_hook' ], 10, 4 );


### PR DESCRIPTION
We add a new option in the plugin settings in order to support installation of WP under a subdirectory. So for instance if the root folder of the webserver hosting WP install is `/var/www/html` and is accessible via `https://my.domain.com/` and if the WP is installed in the sub- directory `var/www/html/cms/` then the plugin option should be `cms` and WP will be accessible via `https://my.domain/com/cms/`.

Note: we support one level of subdirectory, not nested subdirs.

This new option is
compatible with all of the plugin's SEO settings (ie 'Disabled', 'Subdirectory' or 'Subdomain').