### PR TITLE
Support WP install in subdirectory

### DIFF
--- a/includes/admin/transifex-live-integration-admin-template.php
+++ b/includes/admin/transifex-live-integration-admin-template.php
@@ -32,10 +32,15 @@
 
 	<h2><?php _e( '', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></h2>
 	<p class="submit"><input disabled="true" type="button" name="start" id="transifex_live_start" class="button button-primary" value="<?php _e( 'Start Translating NOW', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?>"></p>
-	<a id="start_link" class="hide-if-js" href="<?php echo site_url() . '?transifex'; ?>">Start Translating NOW</a>
+	<a id="start_link" class="hide-if-js" href="<?php echo $site_url . '?transifex'; ?>">Start Translating NOW</a>
 	<h2><?php _e( 'Advanced SEO Settings', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></h2>
 	<p><?php _e( 'This plugin lets you set unique, language/region-specific URLs for your site and tells search engines what language a page is in. This is done by creating new language subdirectories through the plugin, or by pointing to existing language subdomains. In all cases, the plugin will add the Transifex Live JavaScript snippet to your site.', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN ); ?></p>
 	<table class="form-table">
+		<tr>
+			<td>
+				<p><label for="transifex_live_settings_is_subdirectory_install"><?php _e( 'Wordpress is installed under a subdirectory e.g. <code>http://www.example.com/cms/</code> but the site contents are accessed from the root path e.g. <code>http://www.example.com/</code>', TRANSIFEX_LIVE_INTEGRATION_TEXT_DOMAIN); ?>
+				<input name="transifex_live_settings[is_subdirectory_install]" type="checkbox" id="transifex_live_settings_is_subdirectory_install" value="1" <?php echo $checked_is_subdirectory_install ?>></p>
+			</td></tr>
 		<tr>
 			<td>
 				<label for="transifex_live_settings_url_options">

--- a/includes/admin/transifex-live-integration-admin-util.php
+++ b/includes/admin/transifex-live-integration-admin-util.php
@@ -47,6 +47,7 @@ class Transifex_Live_Integration_Admin_Util {
 			return false;
 		}
 
+		$site_url = rtrim($site_url, '/');
 		$slashes = explode( "/", $site_url );
 		if ( $url_option_setting === '3' ) { // Subdirectory option
 			array_push( $slashes, '%lang%' );

--- a/includes/common/plugin-debug.php
+++ b/includes/common/plugin-debug.php
@@ -64,7 +64,7 @@ class Plugin_Debug
         }
     }
 
-    public function printLog() 
+    public static function printLog() 
     {
         if (self::$debug_mode ) {
             echo ('<div id="miw_debug" class="transparent notranslate" style="width:90%;margin: 1em auto;padding: 10px 160px;text-align: left;z-index: 999;">' . "\n");

--- a/includes/common/transifex-live-integration-validators.php
+++ b/includes/common/transifex-live-integration-validators.php
@@ -25,7 +25,7 @@ class Transifex_Live_Integration_Validators {
 			return false;
 		}
 		if ( 3 > substr_count( $link, '/' ) ) {  //Note: this will return for home urls wo the trailing slash
-			Plugin_Debug::logTrace( 'failed validator slash count' );
+			Plugin_Debug::logTrace( 'failed validator slash count '. $link );
 			return false;
 		}
 		return true;

--- a/includes/lib/transifex-live-integration-hreflang.php
+++ b/includes/lib/transifex-live-integration-hreflang.php
@@ -1,6 +1,7 @@
 <?php
 
 include_once TRANSIFEX_LIVE_INTEGRATION_DIRECTORY_BASE . '/includes/common/transifex-live-integration-common.php';
+include_once TRANSIFEX_LIVE_INTEGRATION_DIRECTORY_BASE .'/includes/lib/transifex-live-integration-wp-services.php';
 /**
  * Includes hreflang tag attribute on each page
  * @package TransifexLiveIntegration
@@ -99,7 +100,6 @@ class Transifex_Live_Integration_Hreflang {
 		$ret = [ ];
 		foreach ($languages as $language) {
 			$arr = [ ];
-			$site_url = site_url();
 			$href_link = $url_map[$language];
 			$href_link_parts = explode(':', $href_link);
 			if (count($href_link_parts) && ($href_link_parts[0] === 'http' || $href_link_parts[0] === 'https')) {
@@ -128,7 +128,7 @@ class Transifex_Live_Integration_Hreflang {
 		$url_path = add_query_arg( array(), $wp->request );
 		$source_url_path = (substr( $url_path, 0, strlen( $lang ) ) === $lang) ? substr( $url_path, strlen( $lang ), strlen( $url_path ) ) : $url_path;
 		$source = $this->settings['source_language'];
-		$site_url_slash_maybe = site_url();
+		$site_url_slash_maybe = (new Transifex_Live_Integration_WP_Services($this->settings))->get_site_url();
 		$site_url = rtrim( $site_url_slash_maybe, '/' ) . '/';
 		$source_url_path = ltrim( $source_url_path, '/' );
 		$unslashed_source_url = $site_url . $source_url_path;

--- a/includes/lib/transifex-live-integration-picker.php
+++ b/includes/lib/transifex-live-integration-picker.php
@@ -1,6 +1,7 @@
 <?php
 
 include_once TRANSIFEX_LIVE_INTEGRATION_DIRECTORY_BASE . '/includes/common/transifex-live-integration-common.php';
+include_once TRANSIFEX_LIVE_INTEGRATION_DIRECTORY_BASE .'/includes/lib/transifex-live-integration-wp-services.php';
 
 /**
  * Includes language picker javascript snippet
@@ -37,6 +38,12 @@ class Transifex_Live_Integration_Picker {
 	private $source_language;
 
 	/**
+ 	 * Is the site installed in a subdirectory? (see settings defaults)
+ 	 * @var bool
+ 	 */
+	private $is_subdirectory_install;
+
+	/**
 	 * Constructor
 	 * 
 	 * @param array $language_map A key/value array that maps Transifex locale->plugin code
@@ -45,13 +52,14 @@ class Transifex_Live_Integration_Picker {
 	 * @param string $source_language Current source language
 	 */
 	public function __construct( $language_map, $tokenized_url, $enable_picker,
-			$source_language
+			$source_language, $is_subdirectory_install
 	) {
 		Plugin_Debug::logTrace();
 		$this->language_map = json_decode( $language_map, true )[0];
 		$this->tokenized_url = $tokenized_url;
 		$this->enable_picker = $enable_picker;
 		$this->source_language = $source_language;
+		$this->is_subdirectory_install = $is_subdirectory_install;
 	}
 
 	/*
@@ -66,7 +74,8 @@ class Transifex_Live_Integration_Picker {
 		$url_path = add_query_arg( array(), $wp->request );
 		$source_url_path = (substr( $url_path, 0, strlen( $lang ) ) === $lang) ? substr( $url_path, strlen( $lang ), strlen( $url_path ) ) : $url_path;
 		$url_map = Transifex_Live_Integration_Common::generate_language_url_map( $source_url_path, $this->tokenized_url, $this->language_map );
-		$unslashed_source_url = site_url() . $source_url_path;
+		$site_url = (new Transifex_Live_Integration_WP_Services())->get_site_url($this->is_subdirectory_install);
+		$unslashed_source_url = $site_url . $source_url_path;
 		$url_map[$this->source_language] = rtrim( $unslashed_source_url, '/' ) . '/';
 		$string_url_map = json_encode( $url_map, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 

--- a/includes/lib/transifex-live-integration-subdirectory.php
+++ b/includes/lib/transifex-live-integration-subdirectory.php
@@ -121,6 +121,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 */
 
 	function parse_query_root_hook( $query ) {
+		Plugin_Debug::logTrace();
 		global $wp_query;
 		$check_for_lang = ($query->get( 'lang' ) !== $this->source_language) ? true : false;
 		$check_page = (null !== $query->get( 'page' ) ) ? true : false;
@@ -158,6 +159,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 * @return array Returns filtered rules array
 	 */
 	function post_rewrite_rules_hook( $rules ) {
+		Plugin_Debug::logTrace();
 		if ( !Transifex_Live_Integration_Validators::is_rules_ok( $rules ) ) {
 			return $rules;
 		}
@@ -184,6 +186,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 * @return array Returns custom rewrite rules
 	 */
 	 function custom_type_rules_hook(){
+		Plugin_Debug::logTrace();
 		// Get custom rules from 3rd party module, if our own filter is being used
 		$custom_types_array = array();
 		$custom_types_array = apply_filters('transifex_generate_rewrite_rules', $custom_types_array);
@@ -213,6 +216,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 * @param array $rules Associative array of rewrite rules in WP.
 	 */
 	function date_rewrite_rules_hook( $rules ) {
+		Plugin_Debug::logTrace();
 		if ( !Transifex_Live_Integration_Validators::is_rules_ok( $rules ) ) {
 			return $rules;
 		}
@@ -241,6 +245,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 * @return array Returns filtered rules
 	 */
 	function page_rewrite_rules_hook( $rules ) {
+		Plugin_Debug::logTrace();
 		if ( !Transifex_Live_Integration_Validators::is_rules_ok( $rules ) ) {
 			return $rules;
 		}
@@ -270,6 +275,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 * @param array $rules Associative array of rewrite rules in WP.
 	 */
 	function author_rewrite_rules_hook( $rules ) {
+		Plugin_Debug::logTrace();
 		if ( !Transifex_Live_Integration_Validators::is_rules_ok( $rules ) ) {
 			return $rules;
 		}
@@ -297,6 +303,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 * @param array $rules Associative array of rewrite rules in WP.
 	 */
 	function tag_rewrite_rules_hook( $rules ) {
+		Plugin_Debug::logTrace();
 		if ( !Transifex_Live_Integration_Validators::is_rules_ok( $rules ) ) {
 			return $rules;
 		}
@@ -324,6 +331,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 * @param array $rules Associative array of rewrite rules in WP.
 	 */
 	function category_rewrite_rules_hook( $rules ) {
+		Plugin_Debug::logTrace();
 		if ( !Transifex_Live_Integration_Validators::is_rules_ok( $rules ) ) {
 			return $rules;
 		}
@@ -351,6 +359,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 * @param array $rules Associative array of rewrite rules in WP.
 	 */
 	function search_rewrite_rules_hook( $rules ) {
+		Plugin_Debug::logTrace();
 		if ( !Transifex_Live_Integration_Validators::is_rules_ok( $rules ) ) {
 			return $rules;
 		}
@@ -378,6 +387,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 * @param array $rules Associative array of rewrite rules in WP.
 	 */
 	function feed_rewrite_rules_hook( $rules ) {
+		Plugin_Debug::logTrace();
 		if ( !Transifex_Live_Integration_Validators::is_rules_ok( $rules ) ) {
 			return $rules;
 		}
@@ -403,6 +413,7 @@ class Transifex_Live_Integration_Subdirectory {
 	 * @param array $rules Associative array of rewrite rules in WP.
 	 */
 	function root_rewrite_rules_hook( $rules ) {
+		Plugin_Debug::logTrace();
 		if ( !Transifex_Live_Integration_Validators::is_rules_ok( $rules ) ) {
 			return $rules;
 		}

--- a/includes/lib/transifex-live-integration-wp-services.php
+++ b/includes/lib/transifex-live-integration-wp-services.php
@@ -8,11 +8,33 @@
  * Provides WP services to other classes.
  */
 class Transifex_Live_Integration_WP_Services {
+	/**
+	 * Settings array, corresponds to get_option('transifex_live_settings') from DB.
+	 * @var array
+	 */
+	public $settings;
+
+	public function __construct( $settings = null ) {
+		$this->settings = $settings;
+	}
 
   /*
-	 * Wraps WP site_url().
+	 * Wraps WP site_url() / home_url().
+	 * @param bool $is_subdirectory_install Is the site installed in a subdirectory? (see settings defaults)
+	 *           		                        Use this argument if settings are not available when constructing class.
 	 */
-	function get_site_url() {
-		return site_url();
+	function get_site_url($is_subdirectory_install = null) {
+		$is_subdirectory = false;
+		if (isset($this->settings) && array_key_exists('is_subdirectory_install', $this->settings)) {
+			$is_subdirectory = $this->settings['is_subdirectory_install'];
+		} else if (isset($is_subdirectory_install)) {
+			$is_subdirectory = $is_subdirectory_install;
+		}
+		if (!$is_subdirectory) { // retrieve from db, `home_url(), site_url()` functions cause recursion :(
+			return get_option('siteurl');
+		} else {
+			return get_option('home');
+		}
 	}
+
 }

--- a/includes/transifex-live-integration-defaults.php
+++ b/includes/transifex-live-integration-defaults.php
@@ -1,5 +1,7 @@
 <?php
 
+include_once __DIR__ .'/lib/transifex-live-integration-wp-services.php';
+
 /**
  * Defaults for plugin settings
  * @package TransifexLiveIntegration
@@ -69,18 +71,23 @@ class Transifex_Live_Integration_Defaults {
 		];
 	}
 
-	static function calc_default_subdomain($source_name) {
+	static function calc_default_subdomain($source_name, $is_subdirectory_install = false) {
 		if ( function_exists( 'site_url' ) ) { // sometimes we might run outside of WP
-			$site_url = site_url();
+			// Refer below to calc_default_subdirectory() for explanation of is_subdirectory_install
+			$site_url = (new Transifex_Live_Integration_WP_Services())->get_site_url($is_subdirectory_install);
 		} else {
 			$site_url = 'http://www.mydomain.com';
 		}
 		return str_replace($source_name,'%LANG%',$site_url);
 	}
 
-	static function calc_default_subdirectory() {
+	static function calc_default_subdirectory($is_subdirectory_install = false) {
 		if ( function_exists( 'site_url' ) ) { // sometimes we might run outside of WP
-			$site_url = site_url();
+			// is_subdirectory_install == true is the case when the site is installed in a subdirectory like
+			// wwww.mydomain.com/cms but the site is accessible from www.mydomain.com (root url). In this case
+			// we dont' use the site_url() function because it contains the subdirectory and use the
+			// function home_url() instead.
+			$site_url = (new Transifex_Live_Integration_WP_Services())->get_site_url($is_subdirectory_install);
 		} else {
 			$site_url = 'http://www.mydomain.com';
 		}
@@ -96,6 +103,8 @@ class Transifex_Live_Integration_Defaults {
 			'debug' => '0',
 			'api_key' => null, // This is the only required field and needs to be copied from Live
 			'enable_staging' => 0,
+			// Wordpress is installed in a subdirectory like www.mydomain.com/cms but the site is accessible from www.mydomain.com
+			'is_subdirectory_install' => 0,
 			'previous_api_key' => null,
 			'raw_transifex_languages' => null,
 			'transifex_languages' => null,
@@ -118,6 +127,7 @@ class Transifex_Live_Integration_Defaults {
 			'hreflang' => false,
 			'url_options' => 1,
 			'source_alias' => 'www',
+			// calc_default_subdomain('www') won't work for domain names starting with non-www prefixes
 			'subdomain_pattern' => self::calc_default_subdomain('www'),
 			'subdirectory_pattern' => self::calc_default_subdirectory(),
 			'static_frontpage_support' => false,

--- a/includes/transifex-live-integration-static-factory.php
+++ b/includes/transifex-live-integration-static-factory.php
@@ -148,7 +148,9 @@ class Transifex_Live_Integration_Static_Factory {
 			return false;
 		}
 		include_once TRANSIFEX_LIVE_INTEGRATION_DIRECTORY_BASE . '/includes/lib/transifex-live-integration-picker.php';
-		return new Transifex_Live_Integration_Picker( $settings['language_map'], $settings['tokenized_url'], $settings['enable_picker'], $settings['source_language'] );
+		return new Transifex_Live_Integration_Picker( 
+			$settings['language_map'], $settings['tokenized_url'], $settings['enable_picker'], 
+			$settings['source_language'], $settings['is_subdirectory_install'] );
 	}
 
 	/*

--- a/transifex-live-integration-main.php
+++ b/transifex-live-integration-main.php
@@ -147,11 +147,13 @@ class Transifex_Live_Integration {
 				add_filter( 'day_link', [$rewrite, 'day_link_hook' ], 10, 4 );
 				add_filter( 'month_link', [$rewrite, 'month_link_hook' ], 10, 3 );
 				add_filter( 'year_link', [$rewrite, 'year_link_hook' ], 10, 2 );
-				add_filter( 'home_url', [$rewrite, 'home_url_hook' ] );
-				add_filter( 'the_content', [$rewrite, 'the_content_hook' ], 10);
-				add_filter( 'widget_text', [$rewrite, 'the_content_hook' ], 10);
+				// register 'home_url' with delayed priority to ensure $rewrite->lang is set
+				add_filter( 'home_url', [$rewrite, 'home_url_hook' ], 11, 1 );
+				add_filter( 'the_content', [$rewrite, 'the_content_hook' ], 10, 1);
+				add_filter( 'widget_text', [$rewrite, 'the_content_hook' ], 10, 1);
 				// Add filter for custom content that is not triggered by any other hook
 				add_filter('tx_link',  [ $rewrite,'the_content_hook'], 10 ,1);
+				add_filter( 'comment_form_field_comment', [ $rewrite, 'add_redirect_to_comments_form_hook'], 10, 1);
 			}
 		}
 		$subdirectory = Transifex_Live_Integration_Static_Factory::create_subdirectory( $settings, $rewrite_options );


### PR DESCRIPTION
We add a new option in the plugin settings in order to support installation of WP under a subdirectory. So if the root folder of the webserver hosting WP install is '/var/www/html' and is accessible via 'https://my.domain.com/' and if the WP is installed in the sub- directory '/var/www/html/cms/' then WP admin UI will be accessible via 'https://my.domain/com/cms/wp-admin/...' and WP content from 'https://my.domain/com/...'.

This new option is
compatible with all of the plugin's SEO settings (ie 'Disabled', 'Subdirectory' or 'Subdomain').

To test the new feature, first upate your plugin settings for the new field to be created in the WP db.

Sample excerpt from `docker-compose.yml` to test locally a installation under a `/cms` subfolder (note working_dir and WORDPRESS_CONFIG_EXTRA parameters):
```yml
 wordpress:
   depends_on:
     - db
   image: wordpress:latest
   restart: always
   ports:
     - 8080:80
   working_dir: /var/www/html/cms
   environment:
     WORDPRESS_DB_HOST: db
     WORDPRESS_DB_USER: exampleuser
     WORDPRESS_DB_PASSWORD: examplepass
     WORDPRESS_DB_NAME: exampledb2
     WORDPRESS_CONFIG_EXTRA: |
       define('WP_SITEURL', 'https://92f2-5-203-165-243.ngrok-free.app/cms');
       define('WP_HOME', 'https://92f2-5-203-165-243.ngrok-free.app');

```
In such a local setup after WP is installed under `/cms` folder copy `.htaccess, index.php` files to root folder. The index.php file should contain the following:
```PHP
<?php
/**
 * Front to the WordPress application. This file doesn't do anything, but loads
 * wp-blog-header.php which does and tells WordPress to load the theme.
 *
 * @package WordPress
 */

/**
 * Tells WordPress to load the WordPress theme and output it.
 *
 * @var bool
 */
define( 'WP_USE_THEMES', true );

/** Loads the WordPress Environment and Template */
require __DIR__ . '/cms/wp-blog-header.php';
```
The above steps are required so that WP content is served from the root of local webserver.