### PR TITLE
Fix for urls start with en

### DIFF
--- a/includes/lib/transifex-live-integration-picker.php
+++ b/includes/lib/transifex-live-integration-picker.php
@@ -72,7 +72,7 @@ class Transifex_Live_Integration_Picker {
 		$lang = get_query_var( 'lang' );
 		$home_url = home_url( $wp->request );
 		$url_path = add_query_arg( array(), $wp->request );
-		$source_url_path = (substr( $url_path, 0, strlen( $lang ) ) === $lang) ? substr( $url_path, strlen( $lang ), strlen( $url_path ) ) : $url_path;
+		$source_url_path = (substr($url_path, 0, strlen($lang) + 1) === $lang . '/') ? substr($url_path, strlen($lang) + 1) : $url_path;
 		$url_map = Transifex_Live_Integration_Common::generate_language_url_map( $source_url_path, $this->tokenized_url, $this->language_map );
 		$site_url_slash_maybe = (new Transifex_Live_Integration_WP_Services())->get_site_url($this->is_subdirectory_install);
 		$site_url = rtrim( $site_url_slash_maybe, '/' ) . '/';


### PR DESCRIPTION
When a page/post url starts with "en" and we change the language with a selector, the en included in the url is removed causing some 404