### PR TITLE
TX-15880: Exclude lang_code from urls of images

### DIFF
--- a/includes/lib/transifex-live-integration-picker.php
+++ b/includes/lib/transifex-live-integration-picker.php
@@ -83,6 +83,14 @@ class Transifex_Live_Integration_Picker {
 			$source_url_path = (substr($url_path, 0, strlen($lang)) === $lang) ? substr($url_path, strlen($lang)) : $url_path;
 		}
 		$url_map = Transifex_Live_Integration_Common::generate_language_url_map( $source_url_path, $this->tokenized_url, $this->language_map );
+
+		// Ensure image URLs are not modified by the language prefix
+		foreach ($url_map as $key => $url) {
+			if (strpos($url, '/wp-content/uploads/') !== false) {
+				continue;
+			}
+			$url_map[$key] = rtrim($url, '/') . '/';
+		}
 		$site_url_slash_maybe = (new Transifex_Live_Integration_WP_Services())->get_site_url($this->is_subdirectory_install);
 		$site_url = rtrim( $site_url_slash_maybe, '/' ) . '/';
 		$source_url_path = ltrim( $source_url_path, '/' );


### PR DESCRIPTION
Related to [TX-15880: Exclude lang_code from urls of images](https://transifex.atlassian.net/browse/TX-15880)

Problem and/or solution
-----------------------

How to test
-----------

Reviewer checklist
------------------

For the code:
* [ ] Change is covered by unit-tests
* [ ] Code is well documented, well styled and is following best practices (cf. TEM)
* [ ] Performance issues have been taken under consideration
* [ ] Errors and other edge-cases are handled properly

For the PR:
* [ ] Problem and/or solution are well-explained
* [ ] Commits have been squashed so that each one has a clear purpose
* [ ] Commits have a proper commit message [according to TEM](https://docs.google.com/document/d/115I55MtZqun-fO4kuquMINZ0Kqb5dZZGqy9WFT47T20/edit#heading=h.y7m08tsng7tt)