### PR TITLE
TX-15880: Exclude lang_code from urls of images uploaded to Wordpress

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 
     env:
-      PLUGIN_VERSION: 1.3.45
+      PLUGIN_VERSION: 1.3.46
       WP_PROJECT_TYPE: plugin
       WP_VERSION: latest
       WP_MULTISITE: 0

--- a/includes/lib/transifex-live-integration-rewrite.php
+++ b/includes/lib/transifex-live-integration-rewrite.php
@@ -180,7 +180,9 @@ class Transifex_Live_Integration_Rewrite {
 			$parsed_url = parse_url($link);
 			$link_host = isset($parsed_url['host']) ? $parsed_url['host'] : '';
 			// change only wordpress non-admin links - not links reffering to other domains
-			if ( $link_host === $site_host && strpos($link, '/wp-admin') === false ) {
+			if ( $link_host === $site_host && strpos($link, '/wp-admin') === false
+				&& strpos($link, '/wp-content/uploads') === false
+			) {
 				/* Check if the path starts with the language code,
 				* otherwise prepend it. */
 				$parsed = parse_url( $link );

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 * It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
 
 == Changelog ==
+= 1.3.46 =
+Exclude wordpress uploaded images from subdirectories
+
 = 1.3.45 =
 Add support for custom post links hook
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: txmatthew, ThemeBoy, brooksx
 Tags: transifex, localize, localization, multilingual, international, SEO
 Requires at least: 3.5.2
 Tested up to: 6.5.3
-Stable tag: 1.3.45
+Stable tag: 1.3.46
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
 
 == Changelog ==
+= 1.3.46 =
+Exclude wordpress uploaded images from subdirectories
+
 = 1.3.45 =
 Add support for custom post links hook
 

--- a/transifex-live-integration.php
+++ b/transifex-live-integration.php
@@ -5,13 +5,13 @@
  *
  * @link    https://help.transifex.com/en/articles/6261241-wordpress
  * @package TransifexLiveIntegration
- * @version 1.3.45
+ * @version 1.3.46
  *
  * @wordpress-plugin
  * Plugin Name:       International SEO by Transifex
  * Plugin URI:        https://help.transifex.com/en/articles/6261241-wordpress
  * Description:       Translate your WordPress powered website using Transifex.
- * Version:           1.3.45
+ * Version:           1.3.46
  * License:           GNU General Public License
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       transifex-live-integration
@@ -75,7 +75,7 @@ if ( !defined( 'TRANSIFEX_LIVE_INTEGRATION_REGEX_PATTERN_CHECK_PATTERN' ) ) {
 }
 
 define( 'LANG_PARAM', 'lang' );
-$version = '1.3.45';
+$version = '1.3.46';
 
 require_once( dirname( __FILE__ ) . '/transifex-live-integration-main.php' );
 Transifex_Live_Integration::do_plugin( is_admin(), $version );


### PR DESCRIPTION
Related to [TX-15880: Exclude lang_code from urls of images uploaded to Wordpress](https://transifex.atlassian.net/browse/TX-15880)

Exclude wordpress uploaded images urls from subdirectories since a rewrite rule for these urls  is not supported currently