### PR TITLE
Fix hreflang tags for subdirectory URL option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +25,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 
     env:
-      PLUGIN_VERSION: 1.3.46
+      PLUGIN_VERSION: 1.3.47
       WP_PROJECT_TYPE: plugin
       WP_VERSION: latest
       WP_MULTISITE: 0

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 * It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
 
 == Changelog ==
+= 1.3.47 =
+Fix render hreflang for subdirectories url option
+
 = 1.3.46 =
 Exclude wordpress uploaded images from subdirectories
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: txmatthew, ThemeBoy, brooksx
 Tags: transifex, localize, localization, multilingual, international, SEO
 Requires at least: 3.5.2
 Tested up to: 6.5.3
-Stable tag: 1.3.46
+Stable tag: 1.3.47
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API) in your theme instead of custom code, since this allows you to make your integration more future proof against incompatibilities with 3rd party modules.
 
 == Changelog ==
+= 1.3.47 =
+Fix render hreflang for subdirectories url option
+
 = 1.3.46 =
 Exclude wordpress uploaded images from subdirectories
 

--- a/transifex-live-integration.php
+++ b/transifex-live-integration.php
@@ -5,13 +5,13 @@
  *
  * @link    https://help.transifex.com/en/articles/6261241-wordpress
  * @package TransifexLiveIntegration
- * @version 1.3.46
+ * @version 1.3.47
  *
  * @wordpress-plugin
  * Plugin Name:       International SEO by Transifex
  * Plugin URI:        https://help.transifex.com/en/articles/6261241-wordpress
  * Description:       Translate your WordPress powered website using Transifex.
- * Version:           1.3.46
+ * Version:           1.3.47
  * License:           GNU General Public License
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       transifex-live-integration
@@ -75,7 +75,7 @@ if ( !defined( 'TRANSIFEX_LIVE_INTEGRATION_REGEX_PATTERN_CHECK_PATTERN' ) ) {
 }
 
 define( 'LANG_PARAM', 'lang' );
-$version = '1.3.46';
+$version = '1.3.47';
 
 require_once( dirname( __FILE__ ) . '/transifex-live-integration-main.php' );
 Transifex_Live_Integration::do_plugin( is_admin(), $version );


### PR DESCRIPTION
When the plug-in is configured to create localized URL as subdirectories i.e.:

  `https://www.xxx.com/enact-sample-post/...`

if the URL path coincide to start from one of the used language codes (in the current "example enact-sample-post/..." starts from en - the source language code) the existing code stripped off the presumed lang code which resulted in wrong hreflang tags. In the given example the calculated hreflang tag was:

  `<link rel="alternate" href="www.xxx.com/act-sample-post/..."   hreflang="en>`

This commit fixes this wrong hrelang tags generation.

We also use an updated Ubuntu image for github actions i.e. changes in `.github/workflows/main.yml`