### PR TITLE
TX-16751: Updated Tested Up To field in plugin data

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ International SEO by Transifex
 Contributors: txmatthew, ThemeBoy, brooksx
 Tags: transifex, localize, localization, multilingual, international, SEO
 Requires at least: 3.5.2
-Tested up to: 6.5.3
+Tested up to: 6.9.1
 Stable tag: 1.3.49
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Performed manual testing for WP version 6.9.1 and confirmed compatibility.
Updated `Tested up to` field in plugin data to ensure warning message does not appear.