### PR TITLE
Fix PHP warning

### DIFF
--- a/includes/lib/transifex-live-integration-javascript.php
+++ b/includes/lib/transifex-live-integration-javascript.php
@@ -89,7 +89,12 @@ class Transifex_Live_Integration_Javascript {
 			return false;
 		}
 
-		$lm = json_decode( $language_map, true )[0];
+        $decoded = json_decode( $language_map, true );
+        if ( !is_array( $decoded ) || !isset( $decoded[0] ) ) {
+          Plugin_Debug::logTrace( 'language_map is empty or invalid, defaulting to native lang detection' );
+          return false;
+        }
+        $lm = $decoded[0];
 		$lang = false;
 		if ( $query_var == $source_language ) {
 			$lang = $source_language;


### PR DESCRIPTION
Problem and/or solution
-----------------------
In PHP 8+ environments the following warning is triggered:

PHP Warning: Undefined array key 0 in
/var/www/html/wp-content/plugins/transifex-live-integration/includes /lib/transifex-live-integration-javascript.php on line 92

This commit fixes it.

How to test
-----------------------
1. Create a brand new Wordpress installation (empty WP db) and observe warning in logs when you save for instance the TX Live API key.
2. Do the same with the fixed version: no warning should be logged.
 