### PR TITLE
Bump PHP version, add warning guards

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2]
+        php: [8.1]
     continue-on-error: false
 
     services:
@@ -40,28 +40,29 @@ jobs:
     - name: Set up PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.2
-        extensions: mbstring, xml, ctype, iconv, intl, mysql
+        php-version: 8.1
+        extensions: mbstring, xml, ctype, iconv, intl, mysql, curl
         ini-values: post_max_size=256M, short_open_tag=On
         tools: composer:v2
 
     - name: Install system packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y apache2 libapache2-mod-fcgid nodejs php-fpm
+        sudo apt-get install -y apache2 libapache2-mod-fcgid nodejs php8.1-fpm
         sudo a2enmod rewrite actions fcgid alias proxy_fcgi setenvif
-        sudo a2enconf php7.2-fpm
+        sudo a2enconf php8.1-fpm
 
 
     - name: Composer Global Packages
       run: |
         composer self-update
-        COMPOSER_MEMORY_LIMIT=-1 composer global require "codeception/module-asserts"
-        COMPOSER_MEMORY_LIMIT=-1 composer global require "codeception/codeception"
+        COMPOSER_MEMORY_LIMIT=-1 composer global require "codeception/codeception:^4.2"
+        COMPOSER_MEMORY_LIMIT=-1 composer global require "behat/gherkin:~4.12.0"
+        COMPOSER_MEMORY_LIMIT=-1 composer global require "codeception/module-asserts:^2"
 
     - name: Configure PHP and Apache
       run: |
-        echo "cgi.fix_pathinfo = 1" | sudo tee -a /etc/php/7.2/fpm/php.ini
+        echo "cgi.fix_pathinfo = 1" | sudo tee -a /etc/php/8.1/fpm/php.ini
         # Apache configuration steps
         cd ..
         echo "$(curl -fsSL https://gist.github.com/matthewjackowski/b772ab278efb0e6f30ad/raw/travisci-apache)" | sed -e "s,%TRAVIS_BUILD_DIR%,`pwd`/wordpress,g" | sudo tee /etc/apache2/sites-available/default > /dev/null
@@ -70,7 +71,7 @@ jobs:
         echo "$(curl -fsSL https://gist.githubusercontent.com/matthewjackowski/3b26061241545564ae8d/raw/install-wp-tests.sh)" | sed -e "s@/home/travis/build/transifex/@/home/runner/work/transifex-live-wordpress/@g" |sudo tee ./install-wp-tests.sh > /dev/null
         bash ./install-wp-tests.sh test root '' 127.0.0.1 $WP_VERSION
         sudo service apache2 restart
-        sudo service php7.2-fpm restart
+        sudo service php8.1-fpm restart
 
 
     - name: Run tests

--- a/includes/admin/transifex-live-integration-admin.php
+++ b/includes/admin/transifex-live-integration-admin.php
@@ -209,7 +209,7 @@ class Transifex_Live_Integration_Admin {
 		Plugin_Debug::logTrace();
 
 		if ( isset( $settings['transifex_live_transifex_settings']['settings'] ) ) {
-			$p = json_decode( $settings['transifex_live_transifex_settings']['settings'], true )['production']['picker'];
+			$p = json_decode( $settings['transifex_live_transifex_settings']['settings'], true )['production']['picker'] ?? null;
 			$settings['transifex_live_settings']['enable_picker'] = ($p !== 'no-picker') ? true : false;
 		}
 

--- a/includes/lib/transifex-live-integration-hreflang.php
+++ b/includes/lib/transifex-live-integration-hreflang.php
@@ -55,11 +55,11 @@ class Transifex_Live_Integration_Hreflang {
 	public function __construct( $settings, $rewrite_options ) {
 		Plugin_Debug::logTrace();
 		$this->settings = $settings;
-		$this->language_map = json_decode( $settings['language_map'], true )[0];
+		$this->language_map = json_decode( $settings['language_map'], true )[0] ?? array();
 		$this->languages = json_decode( $settings['transifex_languages'], true );
 		$this->tokenized_url = $settings['tokenized_url'];
 		$this->rewrite_options = $rewrite_options;
-		$this->hreflang_map = json_decode( $settings['hreflang_map'], true )[0];
+		$this->hreflang_map = json_decode( $settings['hreflang_map'], true )[0] ?? array();
 		if ( $settings['url_options'] == '2' ) {
 			$this->url_option_name = 'subdomain';
 		} else if ( $settings['url_options'] == '3' ) {

--- a/includes/lib/transifex-live-integration-javascript.php
+++ b/includes/lib/transifex-live-integration-javascript.php
@@ -125,7 +125,7 @@ class Transifex_Live_Integration_Javascript {
 			$case_map = '';
 			$subdomain_pattern = $this->subdomain_pattern;
 			$source_language = $this->source_language;
-			$language_map = json_decode( $this->language_map, true )[0];
+			$language_map = json_decode( $this->language_map, true )[0] ?? array();
 						$escaped_subdomain_pattern = str_replace('/','\/',$subdomain_pattern);
 			foreach ($language_map as $key => $value) {
 				$case_map .= "case '$value': return '$key'; break; ";

--- a/includes/lib/transifex-live-integration-picker.php
+++ b/includes/lib/transifex-live-integration-picker.php
@@ -55,7 +55,7 @@ class Transifex_Live_Integration_Picker {
 			$source_language, $is_subdirectory_install
 	) {
 		Plugin_Debug::logTrace();
-		$this->language_map = json_decode( $language_map, true )[0];
+		$this->language_map = json_decode( $language_map, true )[0] ?? array();
 		$this->tokenized_url = $tokenized_url;
 		$this->enable_picker = $enable_picker;
 		$this->source_language = $source_language;

--- a/includes/lib/transifex-live-integration-rewrite.php
+++ b/includes/lib/transifex-live-integration-rewrite.php
@@ -49,7 +49,7 @@ class Transifex_Live_Integration_Rewrite {
 		$this->rewrite_options = [ ];
 		$this->languages_regex = $settings['languages_regex'];
 		$this->source_language = $settings['source_language'];
-		$this->languages_map = json_decode( $settings['language_map'], true )[0];
+		$this->languages_map = json_decode( $settings['language_map'], true )[0] ?? array();
 		$this->lang = false; // need to wait before initting
 		if ( isset( $rewrite_options['add_rewrites_post'] ) ) {
 			$this->rewrite_options[] = ($rewrite_options['add_rewrites_post']) ? 'post' : '';
@@ -176,7 +176,7 @@ class Transifex_Live_Integration_Rewrite {
 		if ( count( $m ) > 1 ) {
 			$link = str_replace( $m[1], $lang, $m[0] );
 		} else {
-			$site_host = parse_url($this->wp_services->get_site_url())['host'];
+				$site_host = parse_url($this->wp_services->get_site_url())['host'] ?? '';
 			$parsed_url = parse_url($link);
 			$link_host = isset($parsed_url['host']) ? $parsed_url['host'] : '';
 			// change only wordpress non-admin links - not links reffering to other domains
@@ -186,8 +186,9 @@ class Transifex_Live_Integration_Rewrite {
 				/* Check if the path starts with the language code,
 				* otherwise prepend it. */
 				$parsed = parse_url( $link );
-				if ( substr($parsed['path'], 1, strlen($lang))  != $lang ) {
-					$parsed['path'] = '/' . $lang . $parsed['path'];
+				$current_path = $parsed['path'] ?? '';
+				if ( substr($current_path, 1, strlen($lang))  != $lang ) {
+					$parsed['path'] = '/' . $lang . $current_path;
 				}
 				$link = Transifex_Live_Integration_Util::unparse_url( $parsed );
 			}

--- a/includes/lib/transifex-live-integration-subdirectory.php
+++ b/includes/lib/transifex-live-integration-subdirectory.php
@@ -42,7 +42,7 @@ class Transifex_Live_Integration_Subdirectory {
 		$this->rewrite_options = [ ];
 		$this->languages_regex = $settings['languages_regex'];
 		$this->source_language = $settings['source_language'];
-		$this->languages_map = json_decode( $settings['language_map'], true )[0];
+		$this->languages_map = json_decode( $settings['language_map'], true )[0] ?? array();
 		$this->lang = false;
 		if ( isset( $rewrite_options['add_rewrites_post'] ) ) {
 			$this->rewrite_options[] = ($rewrite_options['add_rewrites_post']) ? 'post' : '';
@@ -256,7 +256,7 @@ class Transifex_Live_Integration_Subdirectory {
 				) {
 					$current_permalink = get_permalink($post->ID);
 					$parsed_url = parse_url($current_permalink);
-					$path = trim($parsed_url['path'], '/');
+					$path = isset($parsed_url['path']) ? trim($parsed_url['path'], '/') : '';
 					if ($post_type === 'post') {
 						$rules['%lang%/' . $path . '?$'] = 'index.php?lang=$matches[1]&name=' . $post->post_name;
 					} elseif ($post_type === 'page') {


### PR DESCRIPTION
Wordpress version is set to `latest`, while PHP is pinned to 7.2.

Go with option to bump PHP version to 8.1.