### PR TITLE
TX-17328: Enable picker setting in different envs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 
     env:
-      PLUGIN_VERSION: 1.3.52
+      PLUGIN_VERSION: 1.3.53
       WP_PROJECT_TYPE: plugin
       WP_VERSION: latest
       WP_MULTISITE: 0

--- a/includes/admin/transifex-live-integration-admin-util.php
+++ b/includes/admin/transifex-live-integration-admin-util.php
@@ -64,6 +64,22 @@ class Transifex_Live_Integration_Admin_Util {
 	}
 
 	/**
+	 * Returns whether the picker library should be enabled, based on the picker
+	 * setting Transifex reports for the environment this site points at.
+	 * The settings payload carries a block per environment, so reading the
+	 * production block on a staging site reports the wrong picker.
+	 * @param string $transifex_settings JSON settings payload from Transifex
+	 * @param bool $enable_staging Whether the site points at the staging environment
+	 * @return bool Returns true unless the environment explicitly has no picker
+	 */
+	static function calc_enable_picker( $transifex_settings, $enable_staging ) {
+		Plugin_Debug::logTrace();
+		$env = ($enable_staging) ? 'staging' : 'production';
+		$picker = json_decode( $transifex_settings, true )[$env]['picker'] ?? null;
+		return ($picker !== 'no-picker');
+	}
+
+	/**
 	 * Renders subdirectory rewrite options
 	 * @param array $options Array of options...usually these will be loaded from defaults
 	 */

--- a/includes/admin/transifex-live-integration-admin.php
+++ b/includes/admin/transifex-live-integration-admin.php
@@ -209,8 +209,10 @@ class Transifex_Live_Integration_Admin {
 		Plugin_Debug::logTrace();
 
 		if ( isset( $settings['transifex_live_transifex_settings']['settings'] ) ) {
-			$p = json_decode( $settings['transifex_live_transifex_settings']['settings'], true )['production']['picker'] ?? null;
-			$settings['transifex_live_settings']['enable_picker'] = ($p !== 'no-picker') ? true : false;
+			$settings['transifex_live_settings']['enable_picker'] = Transifex_Live_Integration_Admin_Util::calc_enable_picker(
+				$settings['transifex_live_transifex_settings']['settings'],
+				!empty( $settings['transifex_live_settings']['enable_staging'] )
+			);
 		}
 
 		$transifex_languages = json_decode( stripslashes( $settings['transifex_live_settings']['transifex_languages'] ), true );

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,9 @@ Ex. $updated_content = apply_filters('tx_link', $original_content);
 
 == Changelog ==
 
+= 1.3.53 =
+Fix keys for picker settings retrieval
+
 = 1.3.52 =
 Fix Permalink settings memory issue
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: txmatthew, ThemeBoy, brooksx
 Tags: transifex, localize, localization, multilingual, international, SEO
 Requires at least: 3.5.2
 Tested up to: 6.9.1
-Stable tag: 1.3.52
+Stable tag: 1.3.53
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -79,6 +79,9 @@ It is also recommended  to use [widgets](https://codex.wordpress.org/Widgets_API
 
 
 == Changelog ==
+
+= 1.3.53 =
+Fix keys for picker settings retrieval
 
 = 1.3.52 =
 Fix Permalink settings memory issue/m

--- a/tests/unit/CalcEnablePickerTest.php
+++ b/tests/unit/CalcEnablePickerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+include_once __DIR__ .'/BaseTestCase.php';
+
+class CalcEnablePickerTest extends BaseTestCase
+{
+
+    private $data;
+
+    protected function setUp(): void
+    {
+        include_once './includes/common/plugin-debug.php';
+        include_once './includes/admin/transifex-live-integration-admin-util.php';
+
+        // Mirrors a manifest where the two environments disagree, which is the
+        // case that used to report the production picker on a staging site.
+        $mixed = json_encode([
+        'staging' => [ 'picker' => 'bottom-left' ],
+        'production' => [ 'picker' => 'no-picker' ],
+        ]);
+        $both_off = json_encode([
+        'staging' => [ 'picker' => 'no-picker' ],
+        'production' => [ 'picker' => 'no-picker' ],
+        ]);
+        $both_on = json_encode([
+        'staging' => [ 'picker' => 'bottom-left' ],
+        'production' => [ 'picker' => 'bottom-right' ],
+        ]);
+
+        $this->data = [[
+        'settings' => $mixed,
+        'enable_staging' => true,
+        'result' => true
+        ],
+        [
+        'settings' => $mixed,
+        'enable_staging' => false,
+        'result' => false
+        ],
+        [
+        'settings' => $both_on,
+        'enable_staging' => false,
+        'result' => true
+        ],
+        [
+        'settings' => $both_off,
+        'enable_staging' => true,
+        'result' => false
+        ],
+        ];
+        // A payload that carries no usable picker setting leaves the picker on
+        $empty_settings = [ '', 'not json', '{}', json_encode([ 'production' => [] ]) ];
+        foreach ($empty_settings as $s) {
+            array_push($this->data, ['settings' => $s, 'enable_staging' => false, 'result' => true ]);
+            array_push($this->data, ['settings' => $s, 'enable_staging' => true, 'result' => true ]);
+        }
+    }
+
+    public function testMe()
+    {
+        foreach ($this->data as $d) {
+            $result = Transifex_Live_Integration_Admin_Util::calc_enable_picker($d['settings'], $d['enable_staging']);
+
+            $this->assertEquals($d['result'], $result);
+        }
+    }
+
+}

--- a/transifex-live-integration.php
+++ b/transifex-live-integration.php
@@ -5,13 +5,13 @@
  *
  * @link    https://help.transifex.com/en/articles/6261241-wordpress
  * @package TransifexLiveIntegration
- * @version 1.3.52
+ * @version 1.3.53
  *
  * @wordpress-plugin
  * Plugin Name:       International SEO by Transifex
  * Plugin URI:        https://help.transifex.com/en/articles/6261241-wordpress
  * Description:       Translate your WordPress powered website using Transifex.
- * Version:           1.3.52
+ * Version:           1.3.53
  * License:           GNU General Public License
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       transifex-live-integration
@@ -75,7 +75,7 @@ if ( !defined( 'TRANSIFEX_LIVE_INTEGRATION_REGEX_PATTERN_CHECK_PATTERN' ) ) {
 }
 
 define( 'LANG_PARAM', 'lang' );
-$version = '1.3.52';
+$version = '1.3.53';
 
 require_once( dirname( __FILE__ ) . '/transifex-live-integration-main.php' );
 Transifex_Live_Integration::do_plugin( is_admin(), $version );


### PR DESCRIPTION
Changed hardcoded `production` key when picker setting is evaluated.

The key is now correct and corresponds to each separate env.